### PR TITLE
Rename /indigo:plugin to /indigo:dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Claude Code plugin for [Indigo](https://www.indigodomo.com) home automation deve
 
 | Command | Description |
 |---------|-------------|
-| `/indigo:plugin` | Plugin development — SDK docs, examples, lifecycle, IOM reference |
+| `/indigo:dev` | Plugin development — SDK docs, examples, lifecycle, IOM reference |
 | `/indigo:api` | API integration — WebSocket and HTTP APIs for client apps |
 | `/indigo:control-pages` | Control page builder — guided XML generation with wireframes |
 

--- a/commands/api.md
+++ b/commands/api.md
@@ -12,7 +12,7 @@ description: Indigo API integration expert — WebSocket and HTTP APIs for clien
 
 Expert assistant for building applications that integrate with Indigo home automation via WebSocket and HTTP APIs. Perfect for iOS/Android apps, web dashboards, and third-party service integrations.
 
-**Note**: This command is for **client-side development** (apps that connect TO Indigo). For **server-side plugin development** (building Indigo plugins), use `/indigo:plugin` instead.
+**Note**: This command is for **client-side development** (apps that connect TO Indigo). For **server-side plugin development** (building Indigo plugins), use `/indigo:dev` instead.
 
 ## CRITICAL: Context Optimization Strategy
 
@@ -165,5 +165,5 @@ Both APIs use **API Keys** or **Local Secrets**:
 
 ## Related Commands
 
-- `/indigo:plugin` — Server-side plugin development
+- `/indigo:dev` — Server-side plugin development
 - `/indigo:control-pages` — Control page builder

--- a/commands/control-pages.md
+++ b/commands/control-pages.md
@@ -118,5 +118,5 @@ Or read `docs/control-pages/export/clipping-export.md` for the manual export pro
 
 ## Related Commands
 
-- `/indigo:plugin` — Server-side plugin development
+- `/indigo:dev` — Server-side plugin development
 - `/indigo:api` — Client-side API integration (WebSocket, HTTP)

--- a/commands/dev.md
+++ b/commands/dev.md
@@ -1,12 +1,12 @@
 ---
-name: plugin
+name: dev
 description: Indigo plugin development expert — SDK docs, examples, lifecycle, IOM reference
 ---
 
 # Indigo Plugin Development Expert
 
 **Plugin**: https://github.com/simons-plugins/indigo-claude-plugin
-**Slash command**: `/indigo:plugin`
+**Slash command**: `/indigo:dev`
 
 ## Description
 

--- a/skills/plugin/SKILL.md
+++ b/skills/plugin/SKILL.md
@@ -36,4 +36,4 @@ You're working on an Indigo plugin. Key resources available:
 
 ## Full Documentation
 
-For comprehensive guidance, use `/indigo:plugin`.
+For comprehensive guidance, use `/indigo:dev`.


### PR DESCRIPTION
## Summary

- Renames the `/indigo:plugin` command to `/indigo:dev` to avoid conflict with Claude's built-in `/plugin` command for managing plugins
- Updates all cross-references in api.md, control-pages.md, README.md, and SKILL.md

## Test plan

- [ ] Verify `/indigo:dev` loads the plugin development skill
- [ ] Verify `/indigo:plugin` no longer appears in command list

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the command alias reference from `/indigo:plugin` to `/indigo:dev` throughout documentation for server-side plugin development features. The command naming change has been applied systematically across all documentation sections, including command tables and references, API guides, related commands lists, development guidance, and quick reference materials to maintain consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->