### PR TITLE
Replace auto-bump with PR version check

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "indigo",
       "source": "./",
       "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "repository": "https://github.com/simons-plugins/indigo-claude-plugin",
       "license": "MIT",
       "keywords": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "indigo",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
   "repository": "https://github.com/simons-plugins/indigo-claude-plugin"
 }

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,73 +1,30 @@
-name: Bump Version
+name: Check Version Bump
 
 on:
-  push:
+  pull_request:
     branches: [main]
 
 jobs:
-  bump:
+  check-version:
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[skip bump]')"
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
-      - name: Check if version was already changed
-        id: check
+      - name: Check version was bumped
         run: |
-          CURRENT=$(python3 -c "import json; print(json.load(open('.claude-plugin/plugin.json'))['version'])")
-          PREVIOUS=$(git show HEAD~1:.claude-plugin/plugin.json 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin)['version'])" 2>/dev/null || echo "0.0.0")
-          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
-          echo "previous=$PREVIOUS" >> "$GITHUB_OUTPUT"
-          if [ "$CURRENT" != "$PREVIOUS" ]; then
-            echo "Version was deliberately changed: $PREVIOUS → $CURRENT"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Version unchanged ($CURRENT), will auto-bump"
-            echo "skip=false" >> "$GITHUB_OUTPUT"
+          PR_VERSION=$(python3 -c "import json; print(json.load(open('.claude-plugin/plugin.json'))['version'])")
+          MAIN_VERSION=$(git show origin/main:.claude-plugin/plugin.json | python3 -c "import sys,json; print(json.load(sys.stdin)['version'])")
+
+          echo "PR version:   $PR_VERSION"
+          echo "Main version: $MAIN_VERSION"
+
+          if [ "$PR_VERSION" = "$MAIN_VERSION" ]; then
+            echo ""
+            echo "::error::Version in .claude-plugin/plugin.json was not bumped ($MAIN_VERSION). Please update the version before merging."
+            exit 1
           fi
 
-      - name: Bump patch version in plugin.json
-        if: steps.check.outputs.skip == 'false'
-        run: |
-          VERSION=${{ steps.check.outputs.current }}
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
-          PATCH=$((PATCH + 1))
-          NEW_VERSION="$MAJOR.$MINOR.$PATCH"
-
-          python3 -c "
-          import json
-          with open('.claude-plugin/plugin.json', 'r') as f:
-              data = json.load(f)
-          data['version'] = '$NEW_VERSION'
-          with open('.claude-plugin/plugin.json', 'w') as f:
-              json.dump(data, f, indent=2)
-              f.write('\n')
-          "
-
-          # Also update marketplace.json if it has a version
-          python3 -c "
-          import json
-          with open('.claude-plugin/marketplace.json', 'r') as f:
-              data = json.load(f)
-          for p in data.get('plugins', []):
-              if 'version' in p:
-                  p['version'] = '$NEW_VERSION'
-          with open('.claude-plugin/marketplace.json', 'w') as f:
-              json.dump(data, f, indent=2)
-              f.write('\n')
-          "
-
-          echo "NEW_VERSION=$NEW_VERSION" >> "$GITHUB_ENV"
-
-      - name: Commit version bump
-        if: steps.check.outputs.skip == 'false'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .claude-plugin/plugin.json .claude-plugin/marketplace.json
-          git commit -m "Bump version to $NEW_VERSION [skip bump]"
-          git push
+          echo ""
+          echo "Version bumped: $MAIN_VERSION → $PR_VERSION"

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -12,19 +12,33 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check version was bumped
+      - name: Check version was bumped and in sync
         run: |
           PR_VERSION=$(python3 -c "import json; print(json.load(open('.claude-plugin/plugin.json'))['version'])")
+          MARKETPLACE_VERSION=$(python3 -c "import json; print(json.load(open('.claude-plugin/marketplace.json'))['plugins'][0]['version'])")
           MAIN_VERSION=$(git show origin/main:.claude-plugin/plugin.json | python3 -c "import sys,json; print(json.load(sys.stdin)['version'])")
 
-          echo "PR version:   $PR_VERSION"
-          echo "Main version: $MAIN_VERSION"
+          echo "plugin.json version:      $PR_VERSION"
+          echo "marketplace.json version: $MARKETPLACE_VERSION"
+          echo "main branch version:      $MAIN_VERSION"
+
+          FAILED=false
 
           if [ "$PR_VERSION" = "$MAIN_VERSION" ]; then
             echo ""
-            echo "::error::Version in .claude-plugin/plugin.json was not bumped ($MAIN_VERSION). Please update the version before merging."
+            echo "::error::Version in plugin.json was not bumped ($MAIN_VERSION). Please update the version before merging."
+            FAILED=true
+          fi
+
+          if [ "$PR_VERSION" != "$MARKETPLACE_VERSION" ]; then
+            echo ""
+            echo "::error::Version mismatch — plugin.json ($PR_VERSION) and marketplace.json ($MARKETPLACE_VERSION) must match."
+            FAILED=true
+          fi
+
+          if [ "$FAILED" = "true" ]; then
             exit 1
           fi
 
           echo ""
-          echo "Version bumped: $MAIN_VERSION → $PR_VERSION"
+          echo "Version bumped: $MAIN_VERSION → $PR_VERSION (plugin.json and marketplace.json in sync)"


### PR DESCRIPTION
## Summary
- Replaces the auto-bump workflow that pushed directly to main (which fails due to branch protection rules)
- New workflow runs on PRs and blocks merging unless the version in `.claude-plugin/plugin.json` has been bumped

## Test plan
- [ ] Open a PR without bumping the version — check should fail
- [ ] Bump version in `plugin.json` and push — check should pass
- [ ] Optionally make this check required in repo branch protection rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version validation workflow to verify version bumps on pull requests before merging, preventing releases without version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->