### PR TITLE
Fix SessionStart update notification hook

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "indigo",
       "source": "./",
       "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "repository": "https://github.com/simons-plugins/indigo-claude-plugin",
       "license": "MIT",
       "keywords": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "indigo",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
   "repository": "https://github.com/simons-plugins/indigo-claude-plugin"
 }

--- a/hooks/check-update.js
+++ b/hooks/check-update.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-// Check for Indigo plugin updates in background, write result to cache
-// Called by SessionStart hook - runs once per session
+// SessionStart hook: read cached update info and inject notification, then refresh cache in background
+// Called synchronously so stdout is captured by Claude Code as additionalContext
 
 const fs = require('fs');
 const path = require('path');
@@ -20,7 +20,32 @@ if (!fs.existsSync(cacheDir)) {
   fs.mkdirSync(cacheDir, { recursive: true });
 }
 
-// Run check in background
+// --- Step 1: Read cache and output notification if update available ---
+let additionalContext = '';
+
+try {
+  if (fs.existsSync(cacheFile)) {
+    const cache = JSON.parse(fs.readFileSync(cacheFile, 'utf8'));
+    if (cache.update_available && cache.installed && cache.latest) {
+      additionalContext = `<important-reminder>Indigo plugin update available: ${cache.installed} → ${cache.latest}. Run /indigo:update to install.</important-reminder>`;
+    }
+  }
+} catch (e) {
+  // Cache read failed - skip notification
+}
+
+// Output JSON for Claude Code context injection
+const output = {};
+if (additionalContext) {
+  output.additional_context = additionalContext;
+  output.hookSpecificOutput = {
+    hookEventName: 'SessionStart',
+    additionalContext: additionalContext
+  };
+}
+console.log(JSON.stringify(output));
+
+// --- Step 2: Refresh cache in background for next session ---
 const child = spawn(process.execPath, ['-e', `
   const fs = require('fs');
   const https = require('https');

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "command": "node '${CLAUDE_PLUGIN_ROOT}/hooks/check-update.js'",
-            "async": true
+            "async": false
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Fixed update check hook running as `async: true` — stdout was never captured by Claude Code
- Changed to synchronous hook that reads cached update info and outputs JSON with `additionalContext`
- Background cache refresh still runs detached for next session
- Bumped version to 1.0.4

## What was broken
The hook wrote `update_available: true` to a cache file but nothing ever read it or output a notification. The `async: true` flag meant stdout was discarded.

## How it works now
1. Session starts → hook reads cache from previous session's background check
2. If update available → outputs JSON with `additionalContext` so Claude sees the notification
3. Spawns background process to refresh cache for next session

## Test plan
- [x] `node hooks/check-update.js` outputs correct JSON with update notification
- [ ] Restart Claude Code and verify notification appears in session

🤖 Generated with [Claude Code](https://claude.com/claude-code)