### PR TITLE
Show release notes in terminal on update

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "indigo",
       "source": "./",
       "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "repository": "https://github.com/simons-plugins/indigo-claude-plugin",
       "license": "MIT",
       "keywords": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "indigo",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
   "repository": "https://github.com/simons-plugins/indigo-claude-plugin"
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Create Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read version from plugin.json
+        id: version
+        run: |
+          VERSION=$(python3 -c "import json; print(json.load(open('.claude-plugin/plugin.json'))['version'])")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag already exists
+        id: check
+        run: |
+          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate release notes from commits
+        if: steps.check.outputs.exists == 'false'
+        id: notes
+        run: |
+          # Find previous tag, or use first commit if none
+          PREV_TAG=$(git tag --sort=-v:refname | head -n1)
+          if [ -z "$PREV_TAG" ]; then
+            RANGE="HEAD"
+          else
+            RANGE="${PREV_TAG}..HEAD"
+          fi
+
+          # Get commit messages (skip merge commits, bump-only commits)
+          NOTES=$(git log "$RANGE" --pretty=format:"- %s" --no-merges \
+            | grep -v "^\- Bump version" \
+            | grep -v "\[skip bump\]" \
+            || echo "- Minor updates")
+
+          # Write to file to preserve newlines
+          echo "$NOTES" > /tmp/release-notes.txt
+          echo "Generated release notes:"
+          cat /tmp/release-notes.txt
+
+      - name: Create tag and release
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ steps.version.outputs.version }}" \
+            --title "v${{ steps.version.outputs.version }}" \
+            --notes-file /tmp/release-notes.txt

--- a/hooks/check-update.js
+++ b/hooks/check-update.js
@@ -27,7 +27,55 @@ try {
   if (fs.existsSync(cacheFile)) {
     const cache = JSON.parse(fs.readFileSync(cacheFile, 'utf8'));
     if (cache.update_available && cache.installed && cache.latest) {
+      // AI context (stdout)
       additionalContext = `<important-reminder>Indigo plugin update available: ${cache.installed} → ${cache.latest}. Run /indigo:update to install.</important-reminder>`;
+
+      // Terminal display (stderr) — visible to the user
+      const yellow = '\x1b[33m';
+      const bold = '\x1b[1m';
+      const dim = '\x1b[2m';
+      const reset = '\x1b[0m';
+
+      const header = `Indigo Plugin Update: ${cache.installed} → ${cache.latest}`;
+      const footer = 'Run /indigo:update to install';
+
+      // Calculate box width from longest line
+      let maxLen = Math.max(header.length, footer.length);
+      const notes = cache.release_notes || [];
+      for (const rel of notes) {
+        const lines = (rel.body || '').split('\n').filter(l => l.trim());
+        const verLine = `v${rel.version}`;
+        maxLen = Math.max(maxLen, verLine.length);
+        for (const line of lines) {
+          maxLen = Math.max(maxLen, line.length);
+        }
+      }
+      const w = maxLen + 4; // padding
+
+      const pad = (s, len) => s + ' '.repeat(Math.max(0, len - s.length));
+
+      let box = '';
+      box += `${yellow}╔${'═'.repeat(w)}╗${reset}\n`;
+      box += `${yellow}║${reset}  ${bold}${header}${reset}${' '.repeat(Math.max(0, w - header.length - 2))}${yellow}║${reset}\n`;
+
+      if (notes.length > 0) {
+        box += `${yellow}╠${'═'.repeat(w)}╣${reset}\n`;
+        for (const rel of notes) {
+          box += `${yellow}║${reset}${' '.repeat(w)}${yellow}║${reset}\n`;
+          const verLine = `v${rel.version}`;
+          box += `${yellow}║${reset}  ${bold}${verLine}${reset}${' '.repeat(Math.max(0, w - verLine.length - 2))}${yellow}║${reset}\n`;
+          const lines = (rel.body || '').split('\n').filter(l => l.trim());
+          for (const line of lines) {
+            box += `${yellow}║${reset}  ${dim}${line}${reset}${' '.repeat(Math.max(0, w - line.length - 2))}${yellow}║${reset}\n`;
+          }
+        }
+      }
+
+      box += `${yellow}║${reset}${' '.repeat(w)}${yellow}║${reset}\n`;
+      box += `${yellow}║${reset}  ${bold}${footer}${reset}${' '.repeat(Math.max(0, w - footer.length - 2))}${yellow}║${reset}\n`;
+      box += `${yellow}╚${'═'.repeat(w)}╝${reset}\n`;
+
+      process.stderr.write(box);
     }
   }
 } catch (e) {

--- a/hooks/check-update.js
+++ b/hooks/check-update.js
@@ -52,6 +52,7 @@ const child = spawn(process.execPath, ['-e', `
 
   const cacheFile = ${JSON.stringify(cacheFile)};
   const pluginJsonFile = ${JSON.stringify(pluginJsonFile)};
+  const REPO = 'simons-plugins/indigo-claude-plugin';
 
   // Read installed version
   let installed = '0.0.0';
@@ -60,38 +61,74 @@ const child = spawn(process.execPath, ['-e', `
     installed = pluginJson.version || '0.0.0';
   } catch (e) {}
 
-  // Fetch latest version from GitHub
-  function fetchLatest() {
+  function httpsGet(url) {
     return new Promise((resolve, reject) => {
       const timeout = setTimeout(() => reject(new Error('timeout')), 10000);
-      const url = 'https://raw.githubusercontent.com/simons-plugins/indigo-claude-plugin/main/.claude-plugin/plugin.json';
       https.get(url, { headers: { 'User-Agent': 'indigo-plugin-update-check' } }, (res) => {
         let data = '';
         res.on('data', (chunk) => data += chunk);
         res.on('end', () => {
           clearTimeout(timeout);
-          try {
-            const json = JSON.parse(data);
-            resolve(json.version || 'unknown');
-          } catch (e) {
-            reject(e);
-          }
+          try { resolve(JSON.parse(data)); }
+          catch (e) { reject(e); }
         });
       }).on('error', reject);
     });
   }
 
-  fetchLatest().then(latest => {
+  async function main() {
+    // Fetch latest version from plugin.json on main
+    let latest = 'unknown';
+    try {
+      const url = 'https://raw.githubusercontent.com/' + REPO + '/main/.claude-plugin/plugin.json';
+      const res = await new Promise((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new Error('timeout')), 10000);
+        https.get(url, { headers: { 'User-Agent': 'indigo-plugin-update-check' } }, (r) => {
+          let data = '';
+          r.on('data', (chunk) => data += chunk);
+          r.on('end', () => { clearTimeout(timeout); resolve(data); });
+        }).on('error', reject);
+      });
+      const json = JSON.parse(res);
+      latest = json.version || 'unknown';
+    } catch (e) {}
+
+    const update_available = latest !== 'unknown' && installed !== latest;
+
+    // Fetch release notes if update available
+    let release_notes = [];
+    if (update_available) {
+      try {
+        const releases = await httpsGet(
+          'https://api.github.com/repos/' + REPO + '/releases?per_page=20'
+        );
+        if (Array.isArray(releases)) {
+          // Collect releases newer than installed version
+          for (const rel of releases) {
+            const ver = (rel.tag_name || '').replace(/^v/, '');
+            if (ver && ver !== installed) {
+              release_notes.push({ version: ver, body: rel.body || '' });
+            }
+            // Stop once we reach the installed version
+            if (ver === installed) break;
+          }
+        }
+      } catch (e) {
+        // Release fetch failed — still cache version info
+      }
+    }
+
     const result = {
-      update_available: latest !== 'unknown' && installed !== latest,
+      update_available,
       installed,
       latest,
+      release_notes,
       checked: Math.floor(Date.now() / 1000)
     };
     fs.writeFileSync(cacheFile, JSON.stringify(result));
-  }).catch(() => {
-    // Network error - skip silently
-  });
+  }
+
+  main();
 `], {
   stdio: 'ignore',
   windowsHide: true,


### PR DESCRIPTION
## Summary
- Add auto-release GitHub Action that creates releases on merge to main with commit messages as notes
- Extend SessionStart hook to fetch and cache release notes from GitHub Releases API
- Display a visible ANSI box in the terminal (via stderr) when an update is available, showing per-version release notes
- Bump version to 1.0.5

## How it works
1. **On merge to main:** New workflow reads version from `plugin.json`, creates a GitHub Release with commit messages as notes
2. **Background (per session):** Hook's background process fetches latest version + release notes, caches them
3. **On next session start:** Hook reads cache and prints a yellow box to stderr showing what changed between installed and latest versions

## Test plan
- [x] Verified ANSI box renders correctly with mock cache data
- [x] Verified background process populates cache with `release_notes` array
- [x] Verified no display when versions match (no false positives)
- [x] Created retroactive releases for v1.0.1–v1.0.4
- [ ] Verify release workflow triggers on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced update notifications now display release notes with information about available changes, improving user awareness of new features and fixes

* **Chores**
  * Version bumped to 1.0.5
  * Automated release workflow added to streamline version management and GitHub release creation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->