### PR TITLE
Document local HTTPS with self-signed certificate support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "indigo",
       "source": "./",
       "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "repository": "https://github.com/simons-plugins/indigo-claude-plugin",
       "license": "MIT",
       "keywords": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "indigo",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
   "repository": "https://github.com/simons-plugins/indigo-claude-plugin"
 }

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -200,19 +200,6 @@ response = requests.get(
 )
 ```
 
-**JavaScript (Node.js)**:
-```javascript
-const https = require('https');
-
-// Create agent that accepts self-signed certificates
-const agent = new https.Agent({ rejectUnauthorized: false });
-
-fetch('https://192.168.1.100:8176/v2/api/indigo.devices', {
-  headers: { 'Authorization': `Bearer ${API_KEY}` },
-  agent
-});
-```
-
 **Swift (iOS/macOS)**:
 ```swift
 // Use a URLSessionDelegate that trusts self-signed certificates

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -173,6 +173,79 @@ http://192.168.1.100:8176/v2/api/indigo.devices
 
 **When to use**: Only on fully trusted networks (home network with WPA2/WPA3 encryption)
 
+**Local HTTPS/WSS (wss:// or https:// with self-signed certificate)**:
+```
+wss://192.168.1.100:8176/v2/api/ws/device-feed
+https://192.168.1.100:8176/v2/api/indigo.devices
+```
+
+✅ Pros: **TLS encryption** on local network, protects credentials in transit
+⚠️ Cons: Uses **self-signed certificate** — clients must explicitly trust it (see below)
+
+**When to use**: When you want encryption on your local network without routing through the Reflector. Indigo's local server generates a self-signed TLS certificate automatically when HTTPS is enabled.
+
+### Handling Self-Signed Certificates (Local HTTPS)
+
+When connecting to Indigo's local HTTPS server, standard TLS validation will reject the self-signed certificate. Your client must explicitly trust it.
+
+**Python**:
+```python
+import requests
+
+# Disable certificate verification for local self-signed cert
+response = requests.get(
+    'https://192.168.1.100:8176/v2/api/indigo.devices',
+    headers={'Authorization': f'Bearer {API_KEY}'},
+    verify=False
+)
+```
+
+**JavaScript (Node.js)**:
+```javascript
+const https = require('https');
+
+// Create agent that accepts self-signed certificates
+const agent = new https.Agent({ rejectUnauthorized: false });
+
+fetch('https://192.168.1.100:8176/v2/api/indigo.devices', {
+  headers: { 'Authorization': `Bearer ${API_KEY}` },
+  agent
+});
+```
+
+**Swift (iOS/macOS)**:
+```swift
+// Use a URLSessionDelegate that trusts self-signed certificates
+class LocalTrustDelegate: NSObject, URLSessionDelegate {
+    static let shared = LocalTrustDelegate()
+
+    func urlSession(_ session: URLSession,
+                    didReceive challenge: URLAuthenticationChallenge,
+                    completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+              let serverTrust = challenge.protectionSpace.serverTrust else {
+            completionHandler(.performDefaultHandling, nil)
+            return
+        }
+        completionHandler(.useCredential, URLCredential(trust: serverTrust))
+    }
+}
+
+// Use with URLSession
+let session = URLSession(configuration: .ephemeral,
+                         delegate: LocalTrustDelegate.shared,
+                         delegateQueue: nil)
+```
+
+**curl**:
+```bash
+# -k flag skips certificate verification
+curl -k -H "Authorization: Bearer API_KEY" \
+  https://192.168.1.100:8176/v2/api/indigo.devices
+```
+
+⚠️ **Important**: Only bypass certificate verification for **local** connections to your own Indigo server. Always use proper certificate validation for remote/Reflector connections.
+
 ### Remote Access (Indigo Reflector)
 
 **Encrypted (wss:// or https://)**:
@@ -181,19 +254,20 @@ wss://REFLECTOR.indigodomo.net/v2/api/ws/device-feed
 https://REFLECTOR.indigodomo.net/v2/api/indigo.devices
 ```
 
-✅ Pros: **TLS encryption**, secure over internet
+✅ Pros: **TLS encryption** with valid certificate, secure over internet
 ❌ Cons: Slightly higher latency
 
 **When to use**: All remote access, mobile apps, public internet
 
 ### Security Recommendations
 
-1. **Use HTTPS/WSS** for all remote connections
+1. **Use HTTPS/WSS** for all connections (remote and local where possible)
 2. **Use API Keys** instead of local secrets
 3. **Enable OAuth** in server preferences
 4. **Firewall rules**: Only expose Indigo server if using Reflector
 5. **Monitor access**: Check Indigo logs for unauthorized attempts
 6. **Revoke unused keys**: Remove old API keys for retired applications
+7. **Local HTTPS**: Enable for encrypted local connections; only trust self-signed certs for your own server
 
 ## Troubleshooting
 

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -133,18 +133,20 @@ Both APIs support the same authentication methods:
 ## Connection Security
 
 ### Local Network
-- `ws://` or `http://` - Unencrypted (use cautiously)
-- Direct connection to Indigo server IP
+- `ws://` or `http://` - Unencrypted (use cautiously, only on trusted networks)
+- `wss://` or `https://` - **Local HTTPS** with self-signed certificate (encrypted, recommended)
+- Direct connection to Indigo server IP on port 8176
 - Fast, low latency
-- Only use on trusted networks
+
+Indigo's local server supports HTTPS with a self-signed TLS certificate. Clients must explicitly trust the self-signed cert (e.g., disable certificate verification for local connections only). This provides encryption without requiring the Reflector.
 
 ### Remote Access (Indigo Reflector)
-- `wss://` or `https://` - TLS encrypted (recommended)
+- `wss://` or `https://` - TLS encrypted with valid certificate (recommended)
 - Connection via `{REFLECTOR}.indigodomo.net`
 - Secure over internet
 - Slightly higher latency
 
-→ See [authentication.md](authentication.md) for security best practices
+→ See [authentication.md](authentication.md) for security best practices and self-signed certificate handling
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- Document local HTTPS/WSS connection option with self-signed certificates
- Add code examples for Python, JavaScript, Swift, and curl

## Test plan
- [ ] Review documentation accuracy against implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed Local HTTPS/WSS guidance with language-specific examples (Python, Swift, curl) and self-signed certificate caveats
  * Clarified remote TLS expectations and emphasized validating certificates for remote connections
  * Unified security recommendations, troubleshooting, authentication guidance, and expanded next-steps/overview content
  * Minor editorial consistency edits around TLS and certificate handling

* **Chores**
  * Bumped plugin version to 1.0.6
<!-- end of auto-generated comment: release notes by coderabbit.ai -->