### PR TITLE
Rename skills/plugin to skills/dev

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "indigo",
       "source": "./",
       "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "repository": "https://github.com/simons-plugins/indigo-claude-plugin",
       "license": "MIT",
       "keywords": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "indigo",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
   "repository": "https://github.com/simons-plugins/indigo-claude-plugin"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,9 @@
 
 ## Release Process
 
-- **Bump version** in `.claude-plugin/plugin.json` with every PR
+- **Bump version** in both `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` with every PR — they must match
+- A CI check enforces version bump and sync between the two files
 - Use semantic versioning: patch for fixes/tweaks, minor for new features
-- The version is checked by the `/indigo:update` command to detect available updates
 
 ## Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,25 @@
+# Indigo Claude Code Plugin
+
+## Release Process
+
+- **Bump version** in `.claude-plugin/plugin.json` with every PR
+- Use semantic versioning: patch for fixes/tweaks, minor for new features
+- The version is checked by the `/indigo:update` command to detect available updates
+
+## Structure
+
+- `commands/` — Slash commands (`/indigo:dev`, `/indigo:api`, `/indigo:control-pages`, `/indigo:update`)
+- `skills/` — Auto-triggered skills (activate on matching file patterns)
+- `hooks/` — Session hooks (e.g., update check on startup)
+- `docs/` — Documentation loaded by commands/skills
+- `sdk-examples/` — 16 official Indigo SDK example plugins
+- `reference/` — SDK reference documents
+- `snippets/` — Plugin templates
+- `examples/` — Control page examples
+- `tools/` — Utility scripts
+
+## Naming Convention
+
+- Avoid using "plugin" for this project's own components — Claude Code uses "plugin" for its own concept
+- Use "skill", "command", "hook" etc. for Claude Code plugin components
+- "Plugin" is fine when referring to Indigo plugins (the things this tool helps build)

--- a/skills/dev/SKILL.md
+++ b/skills/dev/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: plugin
+name: dev
 description: Indigo plugin development guidance
 match:
   - "**/*.indigoPlugin/**"


### PR DESCRIPTION
## Summary
- Renamed `skills/plugin/` directory to `skills/dev/` so the auto-triggered skill registers as `indigo:dev` instead of `indigo:plugin`
- Updated SKILL.md frontmatter `name: plugin` → `name: dev`
- Avoids naming clash with Claude Code's own "plugin" terminology

## Test plan
- [ ] Verify `/indigo:dev` command still works
- [ ] Verify auto-triggered skill fires as `indigo:dev` when editing plugin files
- [ ] Confirm `indigo:plugin` no longer appears in skill list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a top-level configuration field name in skill metadata.
  * Bumped plugin version metadata.

* **Documentation**
  * Added a new guide outlining release process, project structure, and naming conventions.

---

*Note: No user-facing functionality was changed.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->