### PR TITLE
Add lightweight update notification hook

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "indigo",
       "source": "./",
       "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "repository": "https://github.com/simons-plugins/indigo-claude-plugin",
       "license": "MIT",
       "keywords": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "indigo",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
   "repository": "https://github.com/simons-plugins/indigo-claude-plugin"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@
 
 - `commands/` — Slash commands (`/indigo:dev`, `/indigo:api`, `/indigo:control-pages`)
 - `skills/` — Auto-triggered skills (activate on matching file patterns)
+- `hooks/` — SessionStart hook (update availability notification)
 - `docs/` — Documentation loaded by commands/skills
 - `sdk-examples/` — 16 official Indigo SDK example plugins
 - `reference/` — SDK reference documents

--- a/hooks/check-update.js
+++ b/hooks/check-update.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// SessionStart hook: check if a newer version exists and notify via systemMessage.
+// No update logic — users run: /plugin update indigo
+
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const os = require('os');
+
+const REPO = 'simons-plugins/indigo-claude-plugin';
+const CACHE_FILE = path.join(os.homedir(), '.claude', 'cache', 'indigo-plugin-update-check.json');
+const PLUGIN_JSON = path.join(__dirname, '..', '.claude-plugin', 'plugin.json');
+const CACHE_MAX_AGE = 3600; // 1 hour
+
+function getInstalledVersion() {
+  try {
+    return JSON.parse(fs.readFileSync(PLUGIN_JSON, 'utf8')).version || '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+function readCache() {
+  try {
+    const cache = JSON.parse(fs.readFileSync(CACHE_FILE, 'utf8'));
+    if (Date.now() / 1000 - cache.checked < CACHE_MAX_AGE) return cache;
+  } catch {}
+  return null;
+}
+
+function outputResult(installed, latest) {
+  const output = {};
+  if (latest && latest !== installed && latest !== 'unknown') {
+    output.systemMessage = `Indigo plugin update available: ${installed} → ${latest}. Run \`/plugin update indigo\` to install.`;
+  }
+  console.log(JSON.stringify(output));
+}
+
+function refreshCacheInBackground(installed) {
+  const { spawn } = require('child_process');
+  const child = spawn(process.execPath, ['-e', `
+    const fs = require('fs');
+    const https = require('https');
+    const url = 'https://raw.githubusercontent.com/${REPO}/main/.claude-plugin/plugin.json';
+    const req = https.get(url, { headers: { 'User-Agent': 'indigo-update-check' } }, (res) => {
+      let data = '';
+      res.on('data', c => data += c);
+      res.on('end', () => {
+        try {
+          const latest = JSON.parse(data).version || 'unknown';
+          const dir = '${path.dirname(CACHE_FILE).replace(/'/g, "\\'")}';
+          if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+          fs.writeFileSync('${CACHE_FILE.replace(/'/g, "\\'")}', JSON.stringify({
+            installed: '${installed}', latest, checked: Math.floor(Date.now() / 1000)
+          }));
+        } catch {}
+      });
+    });
+    req.on('error', () => {});
+    setTimeout(() => req.destroy(), 10000);
+  `], { stdio: 'ignore', detached: true });
+  child.unref();
+}
+
+// Main
+const installed = getInstalledVersion();
+const cache = readCache();
+
+if (cache) {
+  outputResult(installed, cache.latest);
+} else {
+  console.log(JSON.stringify({}));
+  refreshCacheInBackground(installed);
+}

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node '${CLAUDE_PLUGIN_ROOT}/hooks/check-update.js'",
+            "async": false
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add SessionStart hook that notifies users when a newer version is available
- Directs users to run `/plugin update indigo` (no custom update logic)
- Background fetch caches version check results for 1 hour
- ~70 lines vs the previous 192-line version
- Bump version to 1.0.10

## What changed from the old hook
- Removed all custom update logic (git pull, release notes fetching, terminal box art)
- Notification-only: just tells you a new version exists and how to update
- Points to `/plugin update indigo` instead of the removed `/indigo:update`
- Only triggers on `startup` (not resume/clear/compact)

## Test plan
- [ ] Start a new Claude Code session — no errors from hook
- [ ] Verify `~/.claude/cache/indigo-plugin-update-check.json` gets created in background
- [ ] When cache has a newer version, verify systemMessage appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic update availability notifications that alert users when a newer version is ready to install.

* **Chores**
  * Version bumped to 1.0.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->