### PR TITLE
Improve skill activation, progressive disclosure, and Device Factory docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "indigo",
       "source": "./",
       "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
-      "version": "1.0.10",
+      "version": "1.1.0",
       "repository": "https://github.com/simons-plugins/indigo-claude-plugin",
       "license": "MIT",
       "keywords": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "indigo",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
   "repository": "https://github.com/simons-plugins/indigo-claude-plugin"
 }

--- a/docs/plugin-dev/concepts/devices.md
+++ b/docs/plugin-dev/concepts/devices.md
@@ -106,6 +106,113 @@ States store device data and can trigger events:
 
 **Field Types**: `textfield`, `textarea`, `checkbox`, `menu`, `list`, `button`, `label`, `separator`
 
+## Device Factory Pattern
+
+A Device Factory creates and manages a group of child devices from a single dialog. Use this when a hub or controller discovers multiple sub-devices (e.g., a bridge with relays, dimmers, and sensors).
+
+### Devices.xml Structure
+
+Instead of (or in addition to) individual `<Device>` elements, define a `<DeviceFactory>`:
+
+```xml
+<Devices>
+    <DeviceFactory>
+        <Name>Define Device Group...</Name>
+        <ButtonTitle>Close</ButtonTitle>
+        <ConfigUI>
+            <!-- List showing current devices in the group -->
+            <Field type="list" id="deviceGroupList">
+                <Label>Device group:</Label>
+                <List class="self" method="_get_device_group_list" dynamicReload="true" />
+            </Field>
+            <Field type="separator" id="sep1" />
+            <!-- Buttons to add/remove devices -->
+            <Field type="button" id="addRelay">
+                <Title>Add Relay</Title>
+                <CallbackMethod>_add_relay</CallbackMethod>
+            </Field>
+            <Field type="button" id="removeAll">
+                <Title>Remove All Devices</Title>
+                <CallbackMethod>_remove_all_devices</CallbackMethod>
+            </Field>
+        </ConfigUI>
+    </DeviceFactory>
+
+    <!-- Child device types that the factory creates -->
+    <Device type="relay" id="myRelayType">
+        <Name>Relay</Name>
+        <!-- ... -->
+    </Device>
+    <Device type="dimmer" id="myDimmerType">
+        <Name>Dimmer</Name>
+        <!-- ... -->
+    </Device>
+</Devices>
+```
+
+### Plugin Callbacks
+
+All factory methods receive `dev_id_list` — the list of device IDs currently in the group:
+
+```python
+def getDeviceFactoryUiValues(self, dev_id_list):
+    """Prime initial values for the factory dialog."""
+    values_dict = indigo.Dict()
+    error_msg_dict = indigo.Dict()
+    return (values_dict, error_msg_dict)
+
+def validateDeviceFactoryUi(self, values_dict, dev_id_list):
+    """Validate factory dialog before closing."""
+    errors_dict = indigo.Dict()
+    return (True, values_dict, errors_dict)
+
+def closedDeviceFactoryUi(self, values_dict, user_cancelled, dev_id_list):
+    """Called after factory dialog closes."""
+    pass
+```
+
+### Adding and Removing Devices
+
+Button callbacks create/delete devices using `indigo.device.create()` and `indigo.device.delete()`:
+
+```python
+def _add_relay(self, values_dict, dev_id_list):
+    newdev = indigo.device.create(indigo.kProtocol.Plugin, deviceTypeId="myRelayType")
+    newdev.model = "My Hub"        # Display in UI
+    newdev.subType = "Relay"       # Tab label in UI
+    newdev.replaceOnServer()
+    return values_dict
+
+def _remove_all_devices(self, values_dict, dev_id_list):
+    for dev_id in dev_id_list:
+        try:
+            indigo.device.delete(dev_id)
+        except:
+            pass  # Root element cannot be deleted
+    return values_dict
+```
+
+### Populating the Device Group List
+
+```python
+def _get_device_group_list(self, filter, values_dict, dev_id_list):
+    """Return list of (id, name) tuples for the group list UI."""
+    menu_items = []
+    for dev_id in dev_id_list:
+        if dev_id in indigo.devices:
+            menu_items.append((dev_id, indigo.devices[dev_id].name))
+        else:
+            menu_items.append((dev_id, "- device not found -"))
+    return menu_items
+```
+
+### Important Notes
+
+- Device groups should only contain devices defined by the plugin (not X10/INSTEON/Z-Wave)
+- Set `dev.model` and `dev.subType` after creation, then call `dev.replaceOnServer()`
+- The `dev_id_list` auto-updates after `indigo.device.create()` / `indigo.device.delete()`
+- See the **Example Device - Factory** SDK example for a complete working implementation
+
 ## Device Lifecycle
 
 Device lifecycle callbacks are documented in [Plugin Lifecycle → Device Callbacks](plugin-lifecycle.md#device-lifecycle-callbacks).

--- a/docs/plugin-dev/examples/sdk-examples-guide.md
+++ b/docs/plugin-dev/examples/sdk-examples-guide.md
@@ -15,6 +15,7 @@ This guide explains what each example plugin in the SDK demonstrates and when to
 | [Device - Speed Control](#example-device---speed-control) | Variable speed devices | Fan control, speed levels |
 | [HTTP Responder](#example-http-responder) | Web API or web interface | HTTP handlers, Jinja2 templates, JSON/XML |
 | [Action API](#example-action-api) | Complex plugin actions | Action configuration, YAML processing |
+| [Device - Factory](#example-device---factory) | Hub with multiple child devices | Device groups, add/remove devices |
 | [Database Traverse](#example-database-traverse) | Inspect Indigo database | Iterating devices/variables |
 | [Custom Broadcaster](#example-custom-broadcaster) | Send events to other plugins | Inter-plugin communication |
 | [Custom Subscriber](#example-custom-subscriber) | Receive events from other plugins | Event listening |
@@ -134,6 +135,51 @@ def actionControlSensor(self, action, dev):
 - Tracking electricity usage
 - Power monitoring devices
 - Accumulating usage over time
+
+### Example Device - Factory
+
+**Path**: `../../sdk-examples/Example Device - Factory.indigoPlugin`
+
+**What It Demonstrates**:
+- Device Factory pattern for creating groups of child devices
+- `<DeviceFactory>` element in Devices.xml with ConfigUI buttons
+- Adding and removing devices dynamically via `indigo.device.create()` / `indigo.device.delete()`
+- Factory dialog callbacks: `getDeviceFactoryUiValues`, `validateDeviceFactoryUi`, `closedDeviceFactoryUi`
+- Populating a dynamic device group list
+- Setting `dev.model` and `dev.subType` for UI display
+
+**Use This When**:
+- Building a hub/bridge plugin that discovers multiple sub-devices
+- A single configuration dialog needs to manage multiple device types
+- Users should be able to add/remove devices from a group
+- Different child device types (relay, dimmer, sensor) under one umbrella
+
+**Key Code Sections**:
+- `_add_relay()`, `_add_dimmer()` — Create child devices with `indigo.device.create()`
+- `_remove_relay_devices()`, `_remove_all_devices()` — Delete devices from group
+- `_get_device_group_list()` — Populate the device list in the factory dialog
+- `getDeviceFactoryUiValues()` — Prime initial factory dialog values
+- `validateDeviceFactoryUi()` — Validate before closing factory dialog
+- `actionControlDevice()` — Standard relay/dimmer action handling for child devices
+
+**Factory Pattern**:
+```xml
+<DeviceFactory>
+    <Name>Define Device Group...</Name>
+    <ButtonTitle>Close</ButtonTitle>
+    <ConfigUI>
+        <Field type="list" id="deviceGroupList">
+            <List class="self" method="_get_device_group_list" dynamicReload="true" />
+        </Field>
+        <Field type="button" id="addRelay">
+            <Title>Add Relay</Title>
+            <CallbackMethod>_add_relay</CallbackMethod>
+        </Field>
+    </ConfigUI>
+</DeviceFactory>
+```
+
+**Important**: Device groups should only contain plugin-defined devices. The UI doesn't properly handle X10/INSTEON/Z-Wave devices as group members.
 
 ### Example HTTP Responder
 

--- a/skills/api/SKILL.md
+++ b/skills/api/SKILL.md
@@ -1,33 +1,93 @@
 ---
 name: api
-description: Indigo WebSocket and HTTP API integration guidance
+description: >-
+  This skill should be used when the user asks to "connect to Indigo API",
+  "control Indigo devices remotely", "use Indigo WebSocket", "use Indigo HTTP API",
+  "send commands to Indigo server", "authenticate with Indigo", "get device status",
+  "build an Indigo client app", "subscribe to device changes", "monitor Indigo devices",
+  "build a dashboard for Indigo", "integrate with Indigo REST API", or is working on
+  WebSocket/HTTP client code that communicates with an Indigo home automation server.
+  Provides API integration guidance for both WebSocket and HTTP protocols.
 match:
   - "**/WebSocketService*"
   - "**/IndigoAPI*"
   - "**/IndigoWebSocket*"
   - "**/indigo_api*"
   - "**/indigo_ws*"
+  - "**/indigo*client*"
+  - "**/indigo*connection*"
 ---
 
 # Indigo API Integration
 
-You're working on code that integrates with Indigo's APIs. Key resources available:
+Indigo exposes two transport APIs for remote control. Choose based on use case:
 
-## Quick Reference
+## Transport Selection
 
-- **WebSocket vs HTTP decision**: Read `docs/api/overview.md`
-- **Authentication (API keys, local secrets)**: Read `docs/api/authentication.md`
-- **WebSocket API (real-time, bidirectional)**: Read `docs/api/websocket-api.md`
-- **HTTP API (REST, stateless)**: Read `docs/api/http-api.md`
-- **Device commands**: Read `docs/api/device-commands.md`
+| Use Case | Transport | Why |
+|----------|-----------|-----|
+| iOS/mobile apps | WebSocket | Real-time device updates, bidirectional |
+| Web dashboards | WebSocket | Live state without polling |
+| Scripts/automation | HTTP | Simple, stateless, one-shot commands |
+| Third-party integration | HTTP | Standard REST, easy to integrate |
+| Hybrid apps | Both | HTTP for initial load, WebSocket for live updates |
 
-## Key Patterns
+## Authentication
 
-- **Real-time apps** (iOS, dashboards): Use WebSocket for live device updates
-- **Scripts/automation**: Use HTTP API with curl/requests
-- **Hybrid**: HTTP for initial load, WebSocket for live updates
-- **Auth**: API Keys (recommended) or Local Secrets (local network only)
+Two methods available:
+
+- **API Keys** (recommended) — Works over network, configured in Indigo preferences
+  - Header: `Authorization: Bearer <api-key>`
+- **Local Secrets** — Local network only, auto-generated per-reflector
+  - Only for same-machine or trusted LAN access
+
+## WebSocket Quick Reference
+
+```
+ws[s]://<host>:<port>/v2/api/ws
+```
+
+- **Subscribe**: Send `{"name": "device", "id": <deviceId>}` to receive state changes
+- **Commands**: Send actions via WebSocket messages
+- **Reconnection**: Implement exponential backoff with jitter
+
+## HTTP Quick Reference
+
+```
+GET  /v2/api/indigo.devices         # List all devices
+GET  /v2/api/indigo.devices/<id>    # Get specific device
+PUT  /v2/api/indigo.devices/<id>    # Update device
+POST /v2/api/command                # Execute command
+```
+
+All responses are JSON. Use `?detail=true` for full state information.
+
+## Common Device Commands
+
+```json
+// Turn on
+{"name": "device.turnOn", "parameters": {"id": 123456}}
+
+// Set brightness
+{"name": "device.setBrightness", "parameters": {"id": 123456, "value": 75}}
+
+// Set thermostat
+{"name": "thermostat.setHeatSetpoint", "parameters": {"id": 123456, "value": 72}}
+```
+
+## Reference Documentation
+
+For detailed guidance, read these files relative to `${CLAUDE_PLUGIN_ROOT}`:
+
+| Topic | File |
+|-------|------|
+| WebSocket vs HTTP overview | `docs/api/overview.md` |
+| Authentication setup | `docs/api/authentication.md` |
+| WebSocket API (full) | `docs/api/websocket-api.md` |
+| HTTP REST API (full) | `docs/api/http-api.md` |
+| Device command reference | `docs/api/device-commands.md` |
+| API navigation guide | `docs/api/README.md` |
 
 ## Full Documentation
 
-For comprehensive guidance, use `/indigo:api`.
+For comprehensive guidance with workflow examples, use `/indigo:api`.

--- a/skills/control-pages/SKILL.md
+++ b/skills/control-pages/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: control-pages
-description: Indigo control page building guidance
+description: >-
+  This skill should be used when the user asks to "build a control page",
+  "create an Indigo dashboard", "design a control page layout", "export a control page",
+  "create a .textClipping file", "add device controls to a page", "build a room view",
+  "create a lighting control page", "design a thermostat page", "make a home dashboard",
+  or is working on Indigo control page XML files or .textClipping files.
+  Provides control page XML generation guidance with layout, actions, and export.
 match:
   - "**/*.textClipping"
   - "**/ControlPage*"
@@ -10,27 +16,49 @@ match:
 
 # Indigo Control Pages
 
-You're working on Indigo control pages. Key resources available:
+Control pages are XML-defined touch interfaces for Indigo, displayed on iOS/macOS clients. They contain device controls, status displays, and navigation elements.
 
-## Quick Reference
+## Core Concepts
 
-- **Workflow (5 phases)**: Read `docs/control-pages/workflow.md`
-- **XML structure**: Read `docs/control-pages/schema/control-page.md`
-- **Page elements**: Read `docs/control-pages/schema/page-elements.md`
-- **Actions**: Read `docs/control-pages/schema/actions.md`
-- **Enums**: Read `docs/control-pages/schema/enums.md`
-- **Device images**: Read `docs/control-pages/images/device-images.md`
-- **Screen sizes**: Read `docs/control-pages/layouts/sizing.md`
-- **Templates**: Read `docs/control-pages/layouts/templates.md`
-- **Export**: Read `docs/control-pages/export/clipping-export.md`
+- **Pages** contain positioned **Elements** (icons, text, images)
+- **Elements** reference **Devices** and trigger **Actions** on tap
+- Pages are sized for specific screens (iPhone, iPad, etc.)
+- Export as `.textClipping` files for drag-and-drop import into Indigo
+
+## Element Types
+
+| Element | Use For | Key Property |
+|---------|---------|--------------|
+| Device icon | Controllable devices | `DeviceId` + `ClientActionType` |
+| Variable text | Display variable values | `VariableId` |
+| Static text | Labels, headings | `DisplayText` |
+| Image | Backgrounds, icons | `ImageName` |
+| Navigation | Page links | `LinkedPageName` |
+
+## Action Types (ClientActionType)
+
+| Value | Action | Use For |
+|-------|--------|---------|
+| 0 | None | Display-only elements |
+| 1001 | Toggle on/off | Relays, switches |
+| 1014 | Popup control | Dimmers, thermostats (slider/setpoint) |
+| 1020 | Execute action group | Scenes, macros |
 
 ## Essential Rules
 
-- Use 2x (retina) images for new pages
+- Use 2x (retina) images for all new pages
 - `ClientActionType` 1014 for dimmers/thermostats (popup control)
-- Empty ActionGroup for display-only elements (sensors)
+- Empty `ActionGroup` element for display-only sensors
 - Dark theme background: `19 19 19`
-- Generate unique IDs using random integers
+- Generate unique element IDs using random integers
+- Position elements using `Left`/`Top` coordinates (points, not pixels)
+
+## User Preferences
+
+Read `${CLAUDE_PLUGIN_ROOT}/control-pages.local.md` for user-configured defaults:
+- Screen size presets and default screen
+- Theme colors and typography
+- Icon sizes and layout preferences
 
 ## Export Tool
 
@@ -38,6 +66,22 @@ You're working on Indigo control pages. Key resources available:
 python3 "${CLAUDE_PLUGIN_ROOT}/tools/create_clipping.py" input.xml output.textClipping
 ```
 
+## Reference Documentation
+
+For detailed guidance, read these files relative to `${CLAUDE_PLUGIN_ROOT}`:
+
+| Topic | File |
+|-------|------|
+| 5-phase workflow | `docs/control-pages/workflow.md` |
+| XML schema | `docs/control-pages/schema/control-page.md` |
+| Page elements | `docs/control-pages/schema/page-elements.md` |
+| Actions reference | `docs/control-pages/schema/actions.md` |
+| Enum values | `docs/control-pages/schema/enums.md` |
+| Device images | `docs/control-pages/images/device-images.md` |
+| Screen sizing | `docs/control-pages/layouts/sizing.md` |
+| Layout templates | `docs/control-pages/layouts/templates.md` |
+| Clipping export | `docs/control-pages/export/clipping-export.md` |
+
 ## Full Documentation
 
-For the guided builder workflow, use `/indigo:control-pages`.
+For the guided 5-phase builder workflow, use `/indigo:control-pages`.

--- a/skills/dev/SKILL.md
+++ b/skills/dev/SKILL.md
@@ -1,6 +1,14 @@
 ---
 name: dev
-description: Indigo plugin development guidance
+description: >-
+  This skill should be used when the user asks to "create an Indigo plugin",
+  "build a plugin for Indigo", "add a device type", "configure Devices.xml",
+  "implement plugin lifecycle", "debug an Indigo plugin", "use runConcurrentThread",
+  "add plugin preferences", "create custom events", "update device states",
+  "use replaceOnServer", "create a device factory", "bundle Python packages",
+  "add menu items", "create actions", or is working within .indigoPlugin directory
+  structures. Provides Indigo home automation plugin development guidance including
+  SDK patterns, device design, and troubleshooting.
 match:
   - "**/*.indigoPlugin/**"
   - "**/plugin.py"
@@ -14,26 +22,128 @@ match:
 
 # Indigo Plugin Development
 
-You're working on an Indigo plugin. Key resources available:
+## Plugin Structure
 
-## Quick Reference
+Every Indigo plugin follows this bundle layout:
 
-- **Plugin lifecycle**: Read `docs/plugin-dev/concepts/plugin-lifecycle.md`
-- **Device design (Devices.xml, ConfigUI)**: Read `docs/plugin-dev/concepts/devices.md`
-- **Custom events (Events.xml)**: Read `docs/plugin-dev/concepts/events.md`
-- **Plugin preferences**: Read `docs/plugin-dev/concepts/plugin-preferences.md`
-- **API patterns (state updates, replaceOnServer)**: Read `docs/plugin-dev/patterns/api-patterns.md`
-- **Troubleshooting**: Read `docs/plugin-dev/troubleshooting/common-issues.md`
-- **SDK examples**: Read `docs/plugin-dev/examples/sdk-examples-guide.md`, then load specific example from `sdk-examples/`
+```
+PluginName.indigoPlugin/
+└── Contents/
+    ├── Info.plist              # Unique CFBundleIdentifier required
+    ├── Server Plugin/
+    │   ├── plugin.py           # Main Plugin(indigo.PluginBase) class
+    │   ├── Devices.xml         # Device type definitions
+    │   ├── Actions.xml         # Action definitions
+    │   ├── Events.xml          # Custom event definitions
+    │   ├── MenuItems.xml       # Plugin menu items
+    │   └── PluginConfig.xml    # Plugin preferences UI
+    ├── Resources/              # Web content (auto-served)
+    └── Packages/               # Bundled pip libraries
+```
+
+## Plugin Lifecycle
+
+```python
+class Plugin(indigo.PluginBase):
+    def __init__(self, plugin_id, display_name, version, prefs, **kwargs):
+        super().__init__(plugin_id, display_name, version, prefs, **kwargs)
+        # Instance variables only — NO Indigo API calls here
+
+    def startup(self):
+        # Subscribe to changes, open connections
+        # Do NOT call super().startup()
+
+    def runConcurrentThread(self):  # Optional — polling loop
+        try:
+            while True:
+                # Periodic work
+                self.sleep(60)
+        except self.StopThread:
+            pass  # Clean exit
+
+    def shutdown(self):
+        # Release resources — Do NOT call super().shutdown()
+```
 
 ## Essential Rules
 
 - Always call `super().__init__()` in `__init__` (but NOT super() in startup/shutdown)
 - Use `self.sleep()` not `time.sleep()` in concurrent threads
 - Handle `self.StopThread` in `runConcurrentThread`
-- Log with `self.logger.debug/info/error/exception()`
+- Log with `self.logger.debug/info/warning/error/exception()`
 - Python 3.10+ (Indigo 2023+)
+- Bundle dependencies in `Contents/Packages/` (not system pip)
+- `CFBundleIdentifier` in Info.plist must be globally unique
+
+## Device Types (Devices.xml)
+
+Indigo provides base device types to extend:
+
+| Base Type | Use For | Key States |
+|-----------|---------|------------|
+| `indigo.relay` | On/off switches | `onOffState` |
+| `indigo.dimmer` | Dimmable lights | `onOffState`, `brightnessLevel` |
+| `indigo.thermostat` | Climate control | `hvacMode`, setpoints, temperatures |
+| `indigo.sensor` | Read-only sensors | `onOffState` or `sensorValue` |
+| `custom` | Anything else | Define custom states |
+
+**Device Factory** pattern: A single "factory" device type that creates/manages child devices of different types — useful when a hub discovers multiple sub-devices.
+
+## State Updates
+
+```python
+# Single state
+dev.updateStateOnServer("stateId", value)
+
+# Multiple states (preferred — single server round-trip)
+states = [
+    {"key": "temperature", "value": 72.5, "uiValue": "72.5 °F"},
+    {"key": "humidity", "value": 45, "uiValue": "45%"},
+]
+dev.updateStatesOnServer(states)
+
+# Full device replace (when many properties change)
+dev.replaceOnServer()
+```
+
+## Reference Documentation
+
+For detailed guidance on specific topics, read these files relative to `${CLAUDE_PLUGIN_ROOT}`:
+
+| Topic | File |
+|-------|------|
+| Plugin lifecycle (full) | `docs/plugin-dev/concepts/plugin-lifecycle.md` |
+| Device design & Devices.xml | `docs/plugin-dev/concepts/devices.md` |
+| Custom events | `docs/plugin-dev/concepts/events.md` |
+| Plugin preferences & ConfigUI | `docs/plugin-dev/concepts/plugin-preferences.md` |
+| API patterns (state updates, replaceOnServer) | `docs/plugin-dev/patterns/api-patterns.md` |
+| Troubleshooting | `docs/plugin-dev/troubleshooting/common-issues.md` |
+| SDK examples guide | `docs/plugin-dev/examples/sdk-examples-guide.md` |
+| Indigo Object Model overview | `docs/plugin-dev/api/indigo-object-model.md` |
+
+### IOM Reference (modular)
+
+For specific Indigo Object Model topics, read from `docs/plugin-dev/api/iom/`:
+
+- `architecture.md` — Object hierarchy and base classes
+- `devices.md` — Device properties, methods, base types
+- `command-namespaces.md` — `indigo.device`, `indigo.variable`, etc.
+- `triggers.md` — Trigger types and configuration
+- `subscriptions.md` — Change subscriptions
+- `constants.md` — Enums and constant values
+- `containers.md` — Lists, dictionaries, database access
+- `utilities.md` — Logging, scheduling, server info
+
+### SDK Examples
+
+16 working example plugins in `sdk-examples/`. Read the guide first, then load specific examples as needed. Key examples:
+
+- **Example Device - Custom** — Custom device states, ConfigUI
+- **Example Device - Relay and Dimmer** — Switch/dimmer with on/off/brightness
+- **Example Device - Thermostat** — HVAC, setpoints, fan modes
+- **Example Device - Factory** — Device factory pattern (hub → child devices)
+- **Example HTTP Responder** — Serving web content, REST endpoints
 
 ## Full Documentation
 
-For comprehensive guidance, use `/indigo:dev`.
+For comprehensive guidance with query routing, use `/indigo:dev`.


### PR DESCRIPTION
## Summary
- Rewrite all 3 skill descriptions with specific third-person trigger phrases for better activation matching
- Add inline essential knowledge to all skills (plugin lifecycle, device types, state updates, transport selection, element types, action types) for better progressive disclosure
- Document the Device Factory pattern in `devices.md` and `sdk-examples-guide.md` (was completely missing)
- Bump version to 1.1.0

## Test plan
- [ ] Verify skills trigger on conversational queries (e.g., "create an Indigo plugin", "connect to Indigo API", "build a control page")
- [ ] Verify skills still trigger on file pattern matches
- [ ] Review Device Factory documentation against SDK example for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Device Factory Pattern documentation enabling creation and management of groups of child devices from a single dialog.

* **Documentation**
  * Expanded plugin development guides covering control pages, API integration, device types, and lifecycle management.
  * Added comprehensive examples and reference materials for developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->