### PR TITLE
Complete remaining low-priority documentation gaps

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "indigo",
       "source": "./",
       "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "repository": "https://github.com/simons-plugins/indigo-claude-plugin",
       "license": "MIT",
       "keywords": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "indigo",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
   "repository": "https://github.com/simons-plugins/indigo-claude-plugin"
 }

--- a/docs/plugin-dev/concepts/events.md
+++ b/docs/plugin-dev/concepts/events.md
@@ -226,6 +226,41 @@ def _on_motion_detected(self, zone):
             self.motion_triggers.remove(trigger_id)
 ```
 
+## Event Data Dictionary
+
+When executing action groups or triggers, you can pass an `event_data` dictionary. Indigo automatically adds a `source` key indicating the origin.
+
+### Standard Event Data Keys
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `event-indigo-id` | int | ID of the Indigo object that fired the event |
+| `event-type` | str | Type identifier for the event |
+| `source` | str | Auto-added by Indigo: `"server"`, `"python"`, `"api-http"`, or `"api-websocket"` |
+| `timestamp` | float | Epoch timestamp of the event |
+
+### Webhook Event Data Keys
+
+When events originate from HTTP webhooks, additional keys are present:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `http-method` | str | HTTP method (`GET`, `POST`, etc.) |
+| `request-url` | str | The request URL path |
+| `status-code` | int | HTTP response status code |
+| `webhook-id` | str | Identifier of the webhook |
+| `data` | dict | Parsed request body data |
+
+### Passing Custom Event Data
+
+```python
+event_data = indigo.Dict()
+event_data["scene"] = "evening"
+event_data["triggered_by"] = "schedule"
+indigo.actionGroup.execute(ag.id, event_data=event_data)
+# Indigo auto-adds "source" key to event_data
+```
+
 ## Best Practices
 
 - Use descriptive event IDs and names

--- a/docs/plugin-dev/concepts/scripting-shell.md
+++ b/docs/plugin-dev/concepts/scripting-shell.md
@@ -1,0 +1,58 @@
+# Scripting Shell & CLI
+
+Indigo provides an interactive Python scripting shell and a command-line interface for running scripts outside of plugins.
+
+## Interactive Scripting Shell (IPH)
+
+Open via **Plugins > Open Scripting Shell** in the Indigo application.
+
+The shell provides a Python REPL with full access to the Indigo Object Model:
+
+```python
+>>> indigo.devices["Hallway Light"].onState
+True
+>>> indigo.device.turnOff("Hallway Light")
+>>> indigo.variables["myVar"].value
+'42'
+>>> indigo.variable.updateValue("myVar", value="100")
+```
+
+Useful for:
+- Testing API calls before adding them to a plugin
+- Quick device control and state inspection
+- Debugging device properties and states
+- Exploring the Indigo Object Model interactively
+
+## Command-Line Interface
+
+### Run a Script File
+
+```bash
+/Library/Application\ Support/Perceptive\ Automation/Indigo\ 2023.2/IndigoPluginHost.app/Contents/MacOS/IndigoPluginHost -x /path/to/script.py
+```
+
+### Run Inline Code
+
+```bash
+/Library/Application\ Support/Perceptive\ Automation/Indigo\ 2023.2/IndigoPluginHost.app/Contents/MacOS/IndigoPluginHost -e 'indigo.device.turnOn("Hallway Light")'
+```
+
+### SSH Remote Access
+
+You can run Indigo scripts remotely via SSH:
+
+```bash
+ssh user@indigo-mac '/Library/Application\ Support/Perceptive\ Automation/Indigo\ 2023.2/IndigoPluginHost.app/Contents/MacOS/IndigoPluginHost -e "indigo.server.log(\"Hello from SSH\")"'
+```
+
+## Notes
+
+- The scripting shell and CLI share the same Python environment as plugins
+- Scripts run via CLI have full access to the Indigo Object Model
+- The CLI is useful for cron jobs, automation scripts, and CI/CD integration
+- All logging from CLI scripts appears in the Indigo Event Log
+
+## See Also
+
+- [Plugin Lifecycle](plugin-lifecycle.md) - How plugins run within Indigo
+- [Indigo Object Model](../api/indigo-object-model.md) - Available API

--- a/docs/plugin-dev/quick-start.md
+++ b/docs/plugin-dev/quick-start.md
@@ -234,6 +234,16 @@ sys.path.insert(0, './Contents/Packages')
 import requests
 ```
 
+### Shared Python Libraries
+
+Indigo provides a shared library path for Python modules used across multiple plugins:
+
+```
+/Library/Application Support/Perceptive Automation/Python3-includes/
+```
+
+Place `.py` files here to make them importable by any plugin. After adding or updating files, go to **Plugins > Reload Libraries and Attachments** to pick up changes without restarting Indigo.
+
 ## Common First-Time Issues
 
 ### Plugin Won't Enable

--- a/skills/dev/SKILL.md
+++ b/skills/dev/SKILL.md
@@ -118,6 +118,8 @@ For detailed guidance on specific topics, read these files relative to `${CLAUDE
 | Actions.xml & actionControl callbacks | `docs/plugin-dev/concepts/actions.md` |
 | Menu items (MenuItems.xml) | `docs/plugin-dev/concepts/menu-items.md` |
 | Custom events | `docs/plugin-dev/concepts/events.md` |
+| HTTP Responder (web endpoints, IWS) | `docs/plugin-dev/concepts/http-responder.md` |
+| Scripting shell & CLI | `docs/plugin-dev/concepts/scripting-shell.md` |
 | Plugin preferences & PluginConfig.xml | `docs/plugin-dev/concepts/plugin-preferences.md` |
 | API patterns (state updates, replaceOnServer) | `docs/plugin-dev/patterns/api-patterns.md` |
 | Troubleshooting | `docs/plugin-dev/troubleshooting/common-issues.md` |


### PR DESCRIPTION
## Summary
- Add scripting shell & CLI reference doc (IPH interactive shell, `indigo-host -e`/`-x`, SSH remote access)
- Document shared Python libraries path (`Python3-includes`) and reload mechanism in quick-start
- Add event data dictionary structure (standard + webhook keys) to events doc
- Add HTTP Responder and scripting shell to dev skill routing table
- Bump version to 1.3.0

## Test plan
- [ ] Verify `/indigo:dev` skill routes to new docs correctly
- [ ] Confirm version matches in plugin.json and marketplace.json
- [ ] Review scripting shell doc for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interactive Python scripting shell and command-line interface for plugin development
  * Event Data Dictionary reference for action groups and triggers

* **Documentation**
  * Shared Python Libraries guide for cross-plugin code reuse
  * Scripting shell and CLI reference materials
  * Updated reference documentation with new entries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->