### PR TITLE
Document requirements.txt for Python dependencies

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "indigo",
       "source": "./",
       "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "repository": "https://github.com/simons-plugins/indigo-claude-plugin",
       "license": "MIT",
       "keywords": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "indigo",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
   "repository": "https://github.com/simons-plugins/indigo-claude-plugin"
 }

--- a/docs/plugin-dev/quick-start.md
+++ b/docs/plugin-dev/quick-start.md
@@ -139,8 +139,9 @@ MyPlugin.indigoPlugin/
 │   │   ├── MenuItems.xml          # Plugin menu items
 │   │   ├── PluginConfig.xml       # Plugin configuration UI
 │   │   └── Events.xml             # Event/trigger definitions
+│   │   └── requirements.txt        # Python dependencies (auto-installed)
 │   ├── Resources/                  # Web content (auto-served)
-│   └── Packages/                   # Bundled Python libraries
+│   └── Packages/                   # Auto-managed by Indigo (do not commit)
 ```
 
 **Minimum required files:**
@@ -223,14 +224,38 @@ def validatePrefsConfigUi(self, valuesDict):
 
 ### ❌ Mistake 4: Using system Python packages
 
-```python
-# WRONG - Relies on system packages (may not exist)
-import requests
+Use `requirements.txt` in `Contents/Server Plugin/` — Indigo auto-installs packages on plugin load:
 
-# RIGHT - Bundle packages in Contents/Packages/
-# Install: pip install -t "Contents/Packages/" requests
+```
+# Contents/Server Plugin/requirements.txt
+requests==2.32.5
+paho-mqtt==2.1.0
+```
+
+Then just import normally in `plugin.py`:
+```python
+import requests
+import paho.mqtt.client as mqtt
+```
+
+**How it works:**
+- Indigo runs `pip install` into `Contents/Packages/` automatically on first load
+- Indigo tracks installation via `pip-install-log-success.txt` in `Packages/`
+- Subsequent restarts skip installation if the success marker exists
+- If you change `requirements.txt`, delete the success marker to force reinstall
+
+**Important:**
+- Do NOT commit `Contents/Packages/` to git — add it to `.gitignore`
+- Do NOT manually bundle packages with `pip install -t` — architecture and Python version mismatches will cause `dlopen` errors (e.g. arm64 `.so` on an x86_64 server, or cpython-311 files on Python 3.10)
+- Do NOT use `sys.path.insert()` hacks — Indigo handles the path automatically
+
+```python
+# WRONG - Manual bundling causes architecture/version mismatches
 import sys
 sys.path.insert(0, './Contents/Packages')
+import requests
+
+# RIGHT - Just import. Indigo handles everything via requirements.txt
 import requests
 ```
 
@@ -271,8 +296,9 @@ Place `.py` files here to make them importable by any plugin. After adding or up
 **Symptoms**: `ModuleNotFoundError` or `ImportError` in Event Log
 
 **Solutions**:
-- Bundle all dependencies in `Contents/Packages/`
-- Don't rely on system Python packages
+- Add a `requirements.txt` in `Contents/Server Plugin/` listing your dependencies
+- Delete `Contents/Packages/pip-install-log-success.txt` to force Indigo to reinstall
+- If you see `dlopen` errors with architecture mismatches, remove any manually bundled `.so` files from `Contents/Packages/` and let Indigo reinstall via `requirements.txt`
 - Use Python 3 syntax (not Python 2)
 - Check package compatibility with Python 3.10+
 

--- a/docs/plugin-dev/troubleshooting/common-issues.md
+++ b/docs/plugin-dev/troubleshooting/common-issues.md
@@ -44,8 +44,9 @@
    ```
    ModuleNotFoundError: No module named 'requests'
    ```
-   - Install missing package to `Contents/Packages/` directory
-   - Don't rely on system Python packages
+   - Add a `requirements.txt` in `Contents/Server Plugin/` — Indigo auto-installs on load
+   - Don't manually bundle packages or rely on system Python packages
+   - See [Python Dependencies](#python-dependency-issues) below
 
 3. **API Version Mismatch**
    ```
@@ -271,6 +272,65 @@ def validateDeviceConfigUi(self, values_dict, type_id, dev_id):
 def validateDeviceConfigUi(self, values_dict, type_id, dev_id):
     return (True, values_dict)  # Correct tuple
 ```
+
+## Python Dependency Issues
+
+### Using requirements.txt (Recommended)
+
+Indigo 2023.2+ auto-installs Python packages from `Contents/Server Plugin/requirements.txt`:
+
+```
+# Contents/Server Plugin/requirements.txt
+requests==2.32.5
+paho-mqtt==2.1.0
+zeroconf==0.148.0
+```
+
+**How Indigo handles it:**
+1. On plugin load, Indigo checks for `requirements.txt`
+2. Runs `pip install` into `Contents/Packages/` using Indigo's Python
+3. Creates `Contents/Packages/pip-install-log-success.txt` as a marker
+4. On subsequent restarts, skips installation if the marker exists
+
+### Force Reinstall
+
+If you change `requirements.txt` or packages are corrupted:
+1. Delete `Contents/Packages/pip-install-log-success.txt`
+2. Restart the plugin
+3. Indigo will re-run `pip install`
+
+### Architecture Mismatch Errors
+
+**Symptoms**: `dlopen` error mentioning "incompatible architecture" or wrong cpython version
+```
+dlopen(.../zeroconf/_cache.cpython-311-darwin.so):
+  mach-o file, but is an incompatible architecture (have 'arm64', need 'x86_64')
+```
+
+**Cause**: Packages were manually bundled (`pip install -t`) on a different machine than the Indigo server. Compiled `.so` files are architecture-specific (arm64 vs x86_64) and Python-version-specific (cpython-311 vs cpython-310).
+
+**Solution**:
+1. Remove the manually bundled packages from `Contents/Packages/`
+2. Delete `pip-install-log-success.txt`
+3. Use `requirements.txt` instead — Indigo will install with the correct architecture and Python version
+4. Add `Contents/Packages/` to `.gitignore` to prevent committing compiled files
+
+### Don't Bundle Packages Manually
+
+```python
+# WRONG - sys.path hack with manually bundled packages
+import sys
+sys.path.insert(0, './Contents/Packages')
+import requests
+
+# RIGHT - Just import. Indigo handles everything via requirements.txt
+import requests
+```
+
+**Why manual bundling fails:**
+- `.so` files compiled on arm64 (Apple Silicon) won't work on x86_64 (Intel) servers
+- Files built for Python 3.11 won't load on Python 3.10
+- `__file__` is not defined in Indigo's plugin environment, breaking `os.path.dirname(__file__)` patterns
 
 ## Python 3 Issues
 


### PR DESCRIPTION
## Summary
- Update quick-start.md and common-issues.md to recommend `requirements.txt` over manual package bundling
- Document how Indigo auto-installs dependencies, the `pip-install-log-success.txt` marker, and force reinstall
- Add troubleshooting for architecture mismatch errors (arm64 vs x86_64, cpython version mismatches)
- Document that `__file__` is not available in Indigo's plugin runtime

## Test plan
- [ ] Verify docs render correctly on GitHub
- [ ] Cross-reference with working Sofabaton plugin that uses requirements.txt pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized Python dependency workflow using requirements.txt for plugins and guidance on auto-install behavior.
  * Added caching/marker guidance to control reinstall behavior and optimize startup.
  * Expanded troubleshooting for dependency errors, architecture mismatches, and risks of manual bundling.
* **Chore**
  * Bumped plugin version to 1.3.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->