### PR TITLE
docs: document icon.png for Plugin Store display

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "indigo",
       "source": "./",
       "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "repository": "https://github.com/simons-plugins/indigo-claude-plugin",
       "license": "MIT",
       "keywords": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "indigo",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
   "repository": "https://github.com/simons-plugins/indigo-claude-plugin"
 }

--- a/docs/plugin-dev/quick-start.md
+++ b/docs/plugin-dev/quick-start.md
@@ -141,6 +141,7 @@ MyPlugin.indigoPlugin/
 │   │   └── Events.xml             # Event/trigger definitions
 │   │   └── requirements.txt        # Python dependencies (auto-installed)
 │   ├── Resources/                  # Web content (auto-served)
+│   │   └── icon.png               # Plugin icon (shown in Plugin Store)
 │   └── Packages/                   # Auto-managed by Indigo (do not commit)
 ```
 


### PR DESCRIPTION
## Summary
- Adds `icon.png` to the plugin structure reference in quick-start.md
- `Contents/Resources/icon.png` is displayed in the Indigo Plugin Store but was undocumented

🤖 Generated with [Claude Code](https://claude.com/claude-code)