### PR TITLE
docs: clarify self-contained page design with inline JS

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "indigo",
       "source": "./",
       "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "repository": "https://github.com/simons-plugins/indigo-claude-plugin",
       "license": "MIT",
       "keywords": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "indigo",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
   "repository": "https://github.com/simons-plugins/indigo-claude-plugin"
 }

--- a/commands/html-pages.md
+++ b/commands/html-pages.md
@@ -43,8 +43,9 @@ Produce a single self-contained HTML file. Refer to `references/indigo-api-js.md
 **Requirements:**
 - `indigo-page-*` meta tags for app discovery
 - Inline CSS with `prefers-color-scheme` dark mode support
-- Load `indigo-api.js` via `<script src="../js/indigo-api.js"></script>`
+- **Inline `indigo-api.js`** — paste the full `IndigoAPI` class into a `<script>` block. Pages must be self-contained. Read the class source from `references/indigo-api-js.md`.
 - Use `observeAll()` or `observe(deviceId)` for live polling
+- Guard with `typeof IndigoAPI !== "undefined"` before use
 - Debounce slider inputs (300ms)
 - Handle errors gracefully
 

--- a/skills/html-pages/SKILL.md
+++ b/skills/html-pages/SKILL.md
@@ -83,7 +83,11 @@ Produce a single HTML file. Follow this template structure:
 </head>
 <body>
     <div id="content"></div>
-    <script src="../js/indigo-api.js"></script>
+    <script>
+    // ── indigo-api.js V1 (MUST be inlined — see references/indigo-api-js.md) ──
+    // Paste the full IndigoAPI class and IndigoAPIError class here.
+    // Do NOT use <script src="../js/indigo-api.js"> — it fails in WKWebView.
+    </script>
     <script>
         if (typeof IndigoAPI !== "undefined" && IndigoAPI.isConfigured()) {
             startDashboard();
@@ -103,10 +107,14 @@ Produce a single HTML file. Follow this template structure:
 - Use CSS Grid with `auto-fill, minmax(160px, 1fr)` for responsive card layouts
 - See `references/design-guidelines.md` for full device width table, spacing scale, and scroll behaviour
 
+**Script loading:**
+- Inline the `IndigoAPI` class directly in the page's `<script>` block — pages must be self-contained with no external script dependencies
+- Read the full API class from `references/indigo-api-js.md` and include it in the generated page
+- See `references/design-guidelines.md` "Script Loading" section for the pattern
+
 **Generation rules:**
-- Load `indigo-api.js` via `<script src="../js/indigo-api.js"></script>` (sibling directory)
-- Check `typeof IndigoAPI !== "undefined"` before use — the script tag fails silently when opened as a local file
-- Include a `showConfigForm()` fallback that prompts for server URL and API key (see `examples/active-devices.html` for the pattern)
+- Check `typeof IndigoAPI !== "undefined"` before use — defensive guard in case of unexpected loading issues
+- Include a `showConfigForm()` fallback that prompts for server URL and API key when `INDIGO_CONFIG` is not available (see `examples/active-devices.html` for the pattern)
 - Use CSS custom properties for theming — see `references/design-guidelines.md` for the full theme template
 - Debounce slider inputs at 300ms to avoid command spam
 - Disable toggle controls briefly (500ms) after a command to prevent double-taps

--- a/skills/html-pages/references/design-guidelines.md
+++ b/skills/html-pages/references/design-guidelines.md
@@ -91,6 +91,27 @@ await indigo.setHeatSetpoint(deviceId, 21);
 await indigo.setCoolSetpoint(deviceId, 24);
 ```
 
+## Script Loading
+
+Pages must be self-contained — inline all JavaScript including the `IndigoAPI` class. Do not use external `<script src>` references. Indigo pages are served from authenticated directories and external script requests may not carry credentials in all client environments.
+
+**Pattern:**
+```html
+<script>
+// ── indigo-api.js V1 (inlined) ──
+class IndigoAPI { ... }
+class IndigoAPIError extends Error { ... }
+</script>
+<script>
+if (typeof IndigoAPI !== "undefined" && IndigoAPI.isConfigured()) {
+    const indigo = new IndigoAPI();
+    indigo.observeAll(render, 5000);
+}
+</script>
+```
+
+For the full `IndigoAPI` class source, see `references/indigo-api-js.md`.
+
 ## Sizing and Responsive Layout
 
 Pages are primarily viewed on iPhones of various sizes and iPads. Design mobile-first and scale up.


### PR DESCRIPTION
## Summary

- Update SKILL.md, command, and design guidelines to specify inlining the IndigoAPI class directly in generated pages
- Pages must be self-contained with no external script dependencies
- Remove all remaining Domio-specific references from skill files
- Bump version to 1.4.1

## Test plan

- [ ] Version check CI passes
- [ ] Skill guidance clearly states inline approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)