### PR TITLE
docs: capture html-pages learnings from dining-room session

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "indigo",
       "source": "./",
       "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "repository": "https://github.com/simons-plugins/indigo-claude-plugin",
       "license": "MIT",
       "keywords": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "indigo",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
   "repository": "https://github.com/simons-plugins/indigo-claude-plugin"
 }

--- a/skills/html-pages/SKILL.md
+++ b/skills/html-pages/SKILL.md
@@ -57,6 +57,20 @@ Determine layout, device selection, and interactivity:
 - **Full control** — toggles + brightness sliders + thermostat setpoints
 - **Action buttons** — execute action groups (scenes)
 
+**Capability coverage — CRITICAL:**
+Show controls for EVERY capability a device supports by default. Never silently skip capabilities for layout reasons. If a dimmer has colour temperature support (`supportsWhiteTemperature === true`), its card must include a colour temp slider — even in small/half-width cards. Layout constraints are your problem to solve, not a reason to hide functionality.
+
+If layout genuinely cannot fit all controls, explicitly ask the user before omitting anything:
+> "The [device] supports brightness, colour temperature, and RGB. A small card will be cramped with all three — would you like to skip colour or use a full-width card?"
+
+Detect capabilities from the device object at render time:
+- `dev.supportsOnState` — toggle
+- `dev.brightness != null` / class contains `Dimmer` — brightness slider
+- `dev.supportsWhiteTemperature` — colour temp slider
+- `dev.supportsRGB` — RGB picker
+- `dev.supportsHeatSetpoint` — thermostat setpoint
+- `dev.supportsCoolSetpoint` — cool setpoint
+
 **Polling interval:**
 - Default: 5 seconds (`observeAll(callback, 5000)`)
 - Fast (2s): for security or time-sensitive pages

--- a/skills/html-pages/references/indigo-api-js.md
+++ b/skills/html-pages/references/indigo-api-js.md
@@ -108,3 +108,99 @@ All commands are sent via `POST /v2/api/command` with JSON body:
 ```
 
 Refer to `/indigo:api` skill documentation (`docs/api/device-commands.md`) for the full command reference.
+
+## Capability Detection
+
+Always render controls based on the device's actual capability flags, not on assumptions about device type. A device can be a "dimmer" but also support colour temperature and RGB — all three need controls.
+
+| Capability flag | Control to render |
+|-----------------|-------------------|
+| `dev.supportsOnState === true` | Toggle switch |
+| `dev.class` contains `"Dimmer"` or `dev.brightness != null` | Brightness slider |
+| `dev.supportsWhiteTemperature === true` | Colour temperature slider |
+| `dev.supportsRGB === true` | RGB colour picker |
+| `dev.supportsHeatSetpoint === true` | Heat setpoint control |
+| `dev.supportsCoolSetpoint === true` | Cool setpoint control |
+
+**Rule:** Never hide a supported capability for layout reasons without asking the user first.
+
+## Thermostat Display Rules
+
+For TRVs and thermostats, show heating indicators only when actually heating:
+- **Flame/heat icon:** Only when `hvacHeaterIsOn === true` AND `valve-position > 0`
+- **Valve position at 0%** means the valve is fully closed regardless of `hvacHeaterIsOn` — no flame
+- **Setpoint below ~15°C** usually indicates the zone is off / frost protection mode
+
+## History Endpoint (Domio Plugin)
+
+The Domio plugin exposes a history endpoint backed by Indigo's SQL Logger:
+
+```
+GET /message/com.simons-plugins.domio/history/?device_id={id}&column={name}&range={range}&max_points=200
+```
+
+**Valid `range` values (strict):** `1h`, `6h`, `24h`, `7d`, `30d` — any other value returns 400.
+
+**Parameters:**
+- `device_id` (required) — numeric device ID
+- `column` (optional) — state column to query (e.g. `temperatureInput1`); if omitted, uses first numeric column
+- `range` — time window (strictly one of the allowed values above)
+- `max_points` — downsample target (default 300)
+
+**Response:**
+```json
+{
+  "success": true,
+  "device_id": 123,
+  "column": "temperatureInput1",
+  "range": "24h",
+  "type": "float",
+  "points": [[timestamp, value], ...],
+  "min": 18.2,
+  "max": 22.1,
+  "current": 20.5
+}
+```
+
+**Usage in pages:**
+```javascript
+const data = await indigo._fetch(
+    `/message/com.simons-plugins.domio/history/?device_id=${id}&column=temperatureInput1&range=24h&max_points=200`
+);
+```
+
+## Error Visibility
+
+Silent error handling hides real problems. Every fetch that can fail should display the error on the page, not just `console.warn`. Pattern:
+
+```javascript
+async function loadHistory() {
+    try {
+        const data = await indigo._fetch(path);
+        if (data?.success && data.points?.length > 0) {
+            render(data);
+        } else {
+            showChartMessage(data?.error || "No data available");
+        }
+    } catch (e) {
+        showChartMessage("Error: " + e.message);
+    }
+}
+
+function showChartMessage(msg) {
+    // Write the message into the chart area so the user sees it
+    const el = document.getElementById("chart");
+    if (el) el.innerHTML = `<text>${msg}</text>`;
+}
+```
+
+A page with an invisible 400 error looks identical to a page that's working but has no data. Always surface the difference.
+
+## Script Structure
+
+Use **two separate `<script>` blocks** in the HTML page:
+
+1. **First block** — contains only the `IndigoAPI` class definition
+2. **Second block** — contains all page logic, rendering, event handlers
+
+This means a syntax error or runtime error in the page logic doesn't prevent the API class from being defined, and makes the failure mode more predictable.


### PR DESCRIPTION
## Summary

Updates to the \`/indigo:html-pages\` skill based on findings from building a real room dashboard page (dining room with thermostat + lights + history chart).

**New guidance in SKILL.md:**
- Capability coverage rule: never silently skip device controls for layout reasons. Always show all capabilities a device supports; ask user before omitting anything.

**New sections in \`references/indigo-api-js.md\`:**
- **Capability Detection** — table of device flags and which controls to render for each
- **Thermostat Display Rules** — flame icon only when heating AND valve > 0; setpoint below ~15°C usually means frost protection
- **History Endpoint** — valid \`range\` values are strict (\`1h\`, \`6h\`, \`24h\`, \`7d\`, \`30d\`); other values return 400
- **Error Visibility** — pattern for surfacing errors on the page instead of silent \`console.warn\`
- **Script Structure** — use two separate \`<script>\` blocks so runtime errors in page logic don't prevent the API class from loading

Version bumped to 1.4.2.

## Test plan

- [ ] Version check CI passes
- [ ] Skill docs read coherently for someone generating a new room page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated HTML page design guidelines with critical device capability coverage requirements to ensure all supported capabilities are displayed with appropriate controls
  * Expanded Indigo JavaScript reference documentation including capability-driven UI rendering rules, thermostat display conditions, API endpoint specifications, error handling patterns, and HTML script structure requirements

* **Chores**
  * Version bumped to 1.4.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->