### PR TITLE
docs: address CodeRabbit findings on indigo-api-js reference

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "indigo",
       "source": "./",
       "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "repository": "https://github.com/simons-plugins/indigo-claude-plugin",
       "license": "MIT",
       "keywords": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "indigo",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
   "repository": "https://github.com/simons-plugins/indigo-claude-plugin"
 }

--- a/skills/html-pages/references/indigo-api-js.md
+++ b/skills/html-pages/references/indigo-api-js.md
@@ -127,9 +127,11 @@ Always render controls based on the device's actual capability flags, not on ass
 ## Thermostat Display Rules
 
 For TRVs and thermostats, show heating indicators only when actually heating:
-- **Flame/heat icon:** Only when `hvacHeaterIsOn === true` AND `valve-position > 0`
+- **Flame/heat icon:** Only when `hvacHeaterIsOn === true` AND `dev.states["valve-position"] > 0`
 - **Valve position at 0%** means the valve is fully closed regardless of `hvacHeaterIsOn` — no flame
 - **Setpoint below ~15°C** usually indicates the zone is off / frost protection mode
+
+**Important:** Some Indigo state keys use hyphens (e.g. `valve-position`, `onOffState.ui`). These can only be accessed via **bracket notation** in JavaScript — `dev.states["valve-position"]` — never dot notation, because `dev.states.valve-position` is parsed as a subtraction. Also clamp the returned value: some firmware reports sentinel values (e.g. `-99`) for unknown states.
 
 ## History Endpoint (Domio Plugin)
 
@@ -188,11 +190,15 @@ async function loadHistory() {
 }
 
 function showChartMessage(msg) {
-    // Write the message into the chart area so the user sees it
-    const el = document.getElementById("chart");
-    if (el) el.innerHTML = `<text>${msg}</text>`;
+    // Write the message into the chart area so the user sees it.
+    // Use textContent (not innerHTML) — error messages may come from the
+    // server and must never be interpolated as HTML.
+    const el = document.getElementById("chart-message");
+    if (el) el.textContent = msg;
 }
 ```
+
+For SVG chart containers, either use a dedicated non-SVG overlay element for messages (simpler), or construct an SVG `<text>` element with `document.createElementNS()` and set its `textContent`. Do **not** build HTML strings from error messages — server responses and caught exceptions can contain arbitrary content.
 
 A page with an invisible 400 error looks identical to a page that's working but has no data. Always surface the difference.
 


### PR DESCRIPTION
## Summary

Address CodeRabbit review comments on simons-plugins/indigo-claude-plugin#23 that were missed before merging.

**Verified findings:**

1. **Hyphenated state keys** (valve-position) — Valid finding. The Indigo API does return hyphenated keys for some states (Shelly TRV firmware uses \`valve-position\`). Added an explicit note that these require bracket notation in JavaScript, and warned about sentinel values some firmwares return.

2. **XSS in showChartMessage example** — Valid finding. The doc example used \`innerHTML\` with interpolated error text, which could execute scripts if a server error message contained HTML. Changed to \`textContent\` pattern and added guidance for SVG message overlays.

**Rejected finding:**

3. **"Domio plugin" → "Domio Plugin" capitalization** — Declined. The phrase "The Domio plugin exposes..." uses "plugin" correctly as a common noun. The heading already uses title case ("Domio Plugin"). The repo uses both conventions elsewhere (\`docs/plugin-dev/quick-start.md\` uses "Indigo plugin" lowercase in body text).

Version bumped to 1.4.3.

## Test plan

- [ ] Version check CI passes
- [ ] Example code is safe to copy-paste into new pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
* Released version 1.4.3

**Documentation**
* Enhanced API documentation with clarifications on accessing state values and improved guidance for secure message display and SVG chart rendering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->