### PR TITLE
docs: JSONDateEncoder tip and Jinja2 path clarification

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "indigo",
       "source": "./",
       "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "repository": "https://github.com/simons-plugins/indigo-claude-plugin",
       "license": "MIT",
       "keywords": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "indigo",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
   "repository": "https://github.com/simons-plugins/indigo-claude-plugin"
 }

--- a/docs/plugin-dev/concepts/http-responder.md
+++ b/docs/plugin-dev/concepts/http-responder.md
@@ -66,9 +66,9 @@ def api(self, action, dev=None, caller_waiting_for_result=None):
 ## Content Types
 
 ```python
-# JSON
+# JSON (use JSONDateEncoder to serialize Indigo objects and datetimes)
 reply["headers"]["Content-Type"] = "application/json"
-reply["content"] = json.dumps(data)
+reply["content"] = json.dumps(data, cls=indigo.utils.JSONDateEncoder)
 
 # HTML
 reply["headers"]["Content-Type"] = "text/html"
@@ -81,7 +81,7 @@ reply["content"] = "<response><status>ok</status></response>"
 
 ## Jinja2 Templates
 
-Use Jinja2 for HTML templating. Templates live in `Contents/Resources/templates/`:
+Use Jinja2 for HTML templating. Templates live in `Contents/Resources/templates/`. Note the loader path is relative to `Contents/Server Plugin/` (the plugin's working directory), so `"../Resources/templates"` resolves to `Contents/Resources/templates/`:
 
 ```python
 import jinja2


### PR DESCRIPTION
## Summary
Follow-up polish on the HTTP Responder docs merged in #13.

- Show `json.dumps(data, cls=indigo.utils.JSONDateEncoder)` in the Content Types example so readers serialize Indigo objects/datetimes correctly
- Clarify that the Jinja2 `FileSystemLoader("../Resources/templates")` path is relative to `Contents/Server Plugin/`
- Bump plugin version to 1.4.4

## Test plan
- [x] `check-version` CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped plugin version to 1.4.4

* **Documentation**
  * Updated HTTP responder documentation with clarification on JSON date encoding and Jinja2 template file path resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->