### PR TITLE
feat: /indigo:update-plugins bulk plugin updater

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "indigo",
       "source": "./",
       "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
-      "version": "1.4.4",
+      "version": "1.5.0",
       "repository": "https://github.com/simons-plugins/indigo-claude-plugin",
       "license": "MIT",
       "keywords": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "indigo",
-  "version": "1.4.4",
+  "version": "1.5.0",
   "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
   "repository": "https://github.com/simons-plugins/indigo-claude-plugin"
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Indigo Claude Code Plugin
 
-Claude Code plugin for [Indigo](https://www.indigodomo.com) home automation development. Provides three capabilities as both commands (explicit invocation) and skills (auto-activation).
+Claude Code plugin for [Indigo](https://www.indigodomo.com) home automation development. Provides commands (explicit invocation) and skills (auto-activation) for plugin development, API integration, page building, and server maintenance.
 
 ## Commands
 
@@ -9,6 +9,8 @@ Claude Code plugin for [Indigo](https://www.indigodomo.com) home automation deve
 | `/indigo:dev` | Plugin development — SDK docs, examples, lifecycle, IOM reference |
 | `/indigo:api` | API integration — WebSocket and HTTP APIs for client apps |
 | `/indigo:control-pages` | Control page builder — guided XML generation with wireframes |
+| `/indigo:html-pages` | HTML dashboard builder — self-contained pages with live device controls |
+| `/indigo:update-plugins` | Bulk plugin updater — diff installed plugins against GitHub releases and the Indigo store, then apply upgrades with confirmation |
 
 ## Skills (Auto-Activation)
 

--- a/commands/update-plugins.md
+++ b/commands/update-plugins.md
@@ -1,0 +1,118 @@
+---
+name: update-plugins
+description: Bulk Indigo plugin updater — finds installed plugins whose versions are out of date, previews the diff, and deploys upgrades with confirmation
+---
+
+# Indigo Plugin Bulk Updater
+
+**Plugin**: https://github.com/simons-plugins/indigo-claude-plugin
+**Slash command**: `/indigo:update-plugins`
+
+## Description
+
+Checks every installed Indigo plugin against its upstream source (GitHub releases or the Indigo plugin store), reports which are out of date, and — with confirmation — downloads and deploys the new bundle, then restarts the plugin.
+
+**What it does NOT do:**
+- Install plugins that aren't already present (first installs still require a double-click via Indigo's UI)
+- Roll back on failure
+- Handle paid / authenticated store downloads
+- Run non-interactively — you always confirm before anything is deployed
+
+## On Command Load
+
+1. Read `skills/update-plugins/references/discovery.md` — how to find the upstream source for each installed plugin
+2. Read `skills/update-plugins/references/store-scraping.md` — parse rules for Indigo plugin store detail pages
+3. Read `skills/update-plugins/references/install-workflow.md` — download → verify → rsync → restart sequence
+4. Begin the phased workflow below
+
+## Workflow
+
+Follow every phase in order. Do not skip ahead to apply without showing the report and getting explicit go-ahead.
+
+### Phase 1 — DISCOVER
+
+Call `mcp__indigo__list_plugins` to get every installed plugin. For each entry, capture:
+- `id` (bundle identifier — the match key)
+- `displayName`
+- `version` (installed version)
+- `path` (bundle path on the Indigo server — used later for both reading Info.plist and for the deploy target)
+- `enabled`
+
+**No filtering.** Every installed plugin is a candidate regardless of author.
+
+### Phase 2 — RESOLVE UPGRADE SOURCE
+
+For each installed plugin, determine where to check for updates. See `references/discovery.md` for the full logic. Summary:
+
+1. Read `<path>/Contents/Info.plist` and look for a `GithubInfo` dict with `GithubUser` + `GithubRepo` keys.
+2. If present → source is **GitHub**. Query `gh api /repos/<user>/<repo>/releases/latest` and record tag, version, asset URL, release notes URL.
+3. If absent → source is **store**. Look up the bundle ID in the store cache (Phase 3).
+4. If neither yields a result → source is **unresolved**. Record it but don't block anything else.
+
+Parallelise across plugins. Don't process them one at a time — a 30-plugin serial pass over the network is painfully slow.
+
+### Phase 3 — MAINTAIN STORE CACHE
+
+Store-sourced plugins need a `bundle_id → {name, latest_version, detail_url, download_url, github_url}` map. Cache it at `~/.claude/indigo-plugin-store-cache.json`.
+
+Refresh the cache when:
+- It doesn't exist
+- It is older than 24 hours
+- The user passes a refresh flag (`/indigo:update-plugins refresh`)
+
+Before trusting a freshly refreshed cache, run the parse self-test described in `references/store-scraping.md` — if the HTML has drifted and any of the five required fields are missing for the reference plugin, bail with a clear error rather than silently producing wrong results.
+
+### Phase 4 — DIFF
+
+For every plugin with a resolved source, compare installed version to latest:
+- Use `packaging.version.parse` where possible
+- Fall back to lexicographic comparison for version strings that don't parse cleanly
+- Strip leading `v` before comparing (`v1.0.3` vs `1.0.3`)
+- Treat `YYYY.R.P`, semver, and prereleases as upgrades when the parsed version is strictly greater
+
+Build an upgrade report with columns: `name`, `bundle_id`, `installed → latest`, `source`, `release notes`.
+
+Group the report into three sections:
+- **Upgrades available** — actionable items
+- **Up to date** — informational
+- **Unresolved** — plugins where no upstream source was found (show at the bottom, never treat as an error)
+
+### Phase 5 — CONFIRM
+
+Render the report as a markdown table. Wait for explicit user go-ahead. Accept:
+- `all` → apply every upgrade in the "Upgrades available" section
+- `all except <name>` / `all except <names>` → apply all but the excluded ones
+- A specific plugin name or bundle ID → apply just that one
+- `none` or `no` → stop cleanly, no writes
+
+Do not interpret ambiguous replies as consent. When in doubt, ask again.
+
+### Phase 6 — APPLY (per plugin, one at a time)
+
+For each plugin the user confirmed, follow the sequence in `references/install-workflow.md`. Summary:
+
+1. Download the `.indigoPlugin.zip` (`gh release download` for GitHub, `curl` for store)
+2. Unzip to a temp staging dir
+3. **Safety check**: the staged bundle's `Info.plist` must have the same `CFBundleIdentifier` as the installed plugin and a version matching what the upstream source advertised. If either check fails, abort this plugin's upgrade and continue to the next.
+4. `rsync -av --delete` the staged `Contents/` over the live plugin's `Contents/` (use the `path` returned by MCP — never hardcode a deploy path)
+5. `mcp__indigo__restart_plugin(plugin_id=<bundle_id>)`
+6. Verify: `mcp__indigo__get_plugin_by_id` returns the new version; `mcp__indigo__query_event_log` shows a clean startup (look for the "Started plugin" line and the absence of error lines in the seconds after restart)
+7. Clean up the temp staging dir
+
+Report pass/fail for each plugin. On failure of one plugin, continue to the next — don't halt the whole batch unless the failure indicates something systemic (filesystem unwritable, MCP unreachable).
+
+### Phase 7 — SUMMARY
+
+Report:
+- ✅ Successful upgrades (name, old → new version)
+- ❌ Failed upgrades (name, error, any manual recovery steps)
+- ℹ️ Unresolved plugins (name, reason — no `GithubInfo`, not in store, etc.)
+
+If any plugin failed, suggest a manual next step (check the bundle path, try a manual download, file an issue).
+
+## Safety
+
+- **Never install a new plugin** via this command. If `mcp__indigo__list_plugins` doesn't know about a bundle ID, it's out of scope — the user must double-click install it via Indigo's UI first.
+- **Always verify bundle ID before rsync**. A download from an unexpected source must not clobber a different plugin.
+- **Interactive only**. No cron, no hooks, no silent application. The user always sees the report and types their confirmation.
+- **Use the MCP-reported `path`** for the deploy target, not a hardcoded value. This is how the command works for any user of the marketplace, not just the author.

--- a/commands/update-plugins.md
+++ b/commands/update-plugins.md
@@ -14,16 +14,18 @@ Checks every installed Indigo plugin against its upstream source (GitHub release
 
 **What it does NOT do:**
 - Install plugins that aren't already present (first installs still require a double-click via Indigo's UI)
+- Update disabled plugins (restarting a disabled plugin could re-enable it unexpectedly)
 - Roll back on failure
 - Handle paid / authenticated store downloads
 - Run non-interactively — you always confirm before anything is deployed
 
 ## On Command Load
 
-1. Read `skills/update-plugins/references/discovery.md` — how to find the upstream source for each installed plugin
-2. Read `skills/update-plugins/references/store-scraping.md` — parse rules for Indigo plugin store detail pages
-3. Read `skills/update-plugins/references/install-workflow.md` — download → verify → rsync → restart sequence
-4. Begin the phased workflow below
+1. Read `skills/update-plugins/SKILL.md` — top-level workflow
+2. Read `skills/update-plugins/references/discovery.md` — how to find the upstream source for each installed plugin
+3. Read `skills/update-plugins/references/store-scraping.md` — parse rules for the store fallback
+4. Read `skills/update-plugins/references/install-workflow.md` — the detailed download → verify → rsync → restart sequence
+5. Begin the workflow below
 
 ## Workflow
 
@@ -31,55 +33,43 @@ Follow every phase in order. Do not skip ahead to apply without showing the repo
 
 ### Phase 1 — DISCOVER
 
-Call `mcp__indigo__list_plugins` to get every installed plugin. For each entry, capture:
-- `id` (bundle identifier — the match key)
-- `displayName`
-- `version` (installed version)
-- `path` (bundle path on the Indigo server — used later for both reading Info.plist and for the deploy target)
-- `enabled`
+Call `mcp__indigo__list_plugins` with its default parameters (disabled plugins are excluded automatically — that's what we want). For each returned entry, capture:
 
-**No filtering.** Every installed plugin is a candidate regardless of author.
+- `id` (bundle identifier — the match key)
+- `name` (display name)
+- `version` (installed version)
+- `path` (bundle path on the Indigo server — used for reading Info.plist and as the deploy destination)
+- `enabled`
 
 ### Phase 2 — RESOLVE UPGRADE SOURCE
 
 For each installed plugin, determine where to check for updates. See `references/discovery.md` for the full logic. Summary:
 
-1. Read `<path>/Contents/Info.plist` and look for a `GithubInfo` dict with `GithubUser` + `GithubRepo` keys.
-2. If present → source is **GitHub**. Query `gh api /repos/<user>/<repo>/releases/latest` and record tag, version, asset URL, release notes URL.
+1. Read `<path>/Contents/Info.plist` via `/usr/libexec/PlistBuddy` and look for a `GithubInfo` dict with `GithubUser` + `GithubRepo` keys.
+2. If present → source is **GitHub**. Query `gh api /repos/<user>/<repo>/releases/latest`.
 3. If absent → source is **store**. Look up the bundle ID in the store cache (Phase 3).
-4. If neither yields a result → source is **unresolved**. Record it but don't block anything else.
+4. If neither yields a result → source is **unresolved**.
 
-Parallelise across plugins. Don't process them one at a time — a 30-plugin serial pass over the network is painfully slow.
+Parallelise across plugins — a 30-plugin serial pass over the network is painfully slow.
 
 ### Phase 3 — MAINTAIN STORE CACHE
 
-Store-sourced plugins need a `bundle_id → {name, latest_version, detail_url, download_url, github_url}` map. Cache it at `~/.claude/indigo-plugin-store-cache.json`.
-
-Refresh the cache when:
-- It doesn't exist
-- It is older than 24 hours
-- The user passes a refresh flag (`/indigo:update-plugins refresh`)
-
-Before trusting a freshly refreshed cache, run the parse self-test described in `references/store-scraping.md` — if the HTML has drifted and any of the five required fields are missing for the reference plugin, bail with a clear error rather than silently producing wrong results.
+Cache lives at `$HOME/.claude/indigo-plugin-store-cache.json`. Refresh when missing, older than 24 hours, or on user request. Before trusting a freshly refreshed cache, run the parse self-test in `references/store-scraping.md` — if the HTML has drifted, bail with a clear error rather than silently producing wrong results.
 
 ### Phase 4 — DIFF
 
-For every plugin with a resolved source, compare installed version to latest:
-- Use `packaging.version.parse` where possible
-- Fall back to lexicographic comparison for version strings that don't parse cleanly
-- Strip leading `v` before comparing (`v1.0.3` vs `1.0.3`)
-- Treat `YYYY.R.P`, semver, and prereleases as upgrades when the parsed version is strictly greater
+For every plugin with a resolved source, compare installed version to latest. Strip leading `v`. Prefer `python3 -c 'from packaging.version import parse as p; ...'` when Python is available; fall back to split-on-`.` numeric-or-string segment compare. Handles `2026.4.1`, `1.0.3`, and `v1.0-beta`.
 
-Build an upgrade report with columns: `name`, `bundle_id`, `installed → latest`, `source`, `release notes`.
+Build an upgrade report grouped into three sections:
 
-Group the report into three sections:
 - **Upgrades available** — actionable items
 - **Up to date** — informational
-- **Unresolved** — plugins where no upstream source was found (show at the bottom, never treat as an error)
+- **Unresolved** — plugins where no upstream source was found (bottom of the report, never an error)
 
 ### Phase 5 — CONFIRM
 
-Render the report as a markdown table. Wait for explicit user go-ahead. Accept:
+Render the report. Wait for explicit user go-ahead. Accept:
+
 - `all` → apply every upgrade in the "Upgrades available" section
 - `all except <name>` / `all except <names>` → apply all but the excluded ones
 - A specific plugin name or bundle ID → apply just that one
@@ -89,30 +79,20 @@ Do not interpret ambiguous replies as consent. When in doubt, ask again.
 
 ### Phase 6 — APPLY (per plugin, one at a time)
 
-For each plugin the user confirmed, follow the sequence in `references/install-workflow.md`. Summary:
+Follow `references/install-workflow.md` for the exact sequence. Every step — download, unzip-before-copy, verify bundle ID, rsync over the installed `Contents/`, restart via MCP, verify startup — is documented there with the commands to run. Don't reinvent the sequence here.
 
-1. Download the `.indigoPlugin.zip` (`gh release download` for GitHub, `curl` for store)
-2. Unzip to a temp staging dir
-3. **Safety check**: the staged bundle's `Info.plist` must have the same `CFBundleIdentifier` as the installed plugin and a version matching what the upstream source advertised. If either check fails, abort this plugin's upgrade and continue to the next.
-4. `rsync -av --delete` the staged `Contents/` over the live plugin's `Contents/` (use the `path` returned by MCP — never hardcode a deploy path)
-5. `mcp__indigo__restart_plugin(plugin_id=<bundle_id>)`
-6. Verify: `mcp__indigo__get_plugin_by_id` returns the new version; `mcp__indigo__query_event_log` shows a clean startup (look for the "Started plugin" line and the absence of error lines in the seconds after restart)
-7. Clean up the temp staging dir
-
-Report pass/fail for each plugin. On failure of one plugin, continue to the next — don't halt the whole batch unless the failure indicates something systemic (filesystem unwritable, MCP unreachable).
+Report pass/fail per plugin. On failure of one plugin, continue to the next — don't halt the whole batch unless the failure indicates something systemic (filesystem unwritable, MCP unreachable, network dead).
 
 ### Phase 7 — SUMMARY
 
-Report:
-- ✅ Successful upgrades (name, old → new version)
-- ❌ Failed upgrades (name, error, any manual recovery steps)
-- ℹ️ Unresolved plugins (name, reason — no `GithubInfo`, not in store, etc.)
+Report three sections:
 
-If any plugin failed, suggest a manual next step (check the bundle path, try a manual download, file an issue).
+- **Upgraded** — name, old → new version
+- **Failed** — name, error, a one-line manual recovery hint
+- **Unresolved** — name, reason (no GithubInfo, not in store, etc.)
+
+If any plugin failed, suggest a concrete manual next step (check the bundle path, try a manual download, file an issue with the plugin author).
 
 ## Safety
 
-- **Never install a new plugin** via this command. If `mcp__indigo__list_plugins` doesn't know about a bundle ID, it's out of scope — the user must double-click install it via Indigo's UI first.
-- **Always verify bundle ID before rsync**. A download from an unexpected source must not clobber a different plugin.
-- **Interactive only**. No cron, no hooks, no silent application. The user always sees the report and types their confirmation.
-- **Use the MCP-reported `path`** for the deploy target, not a hardcoded value. This is how the command works for any user of the marketplace, not just the author.
+All safety rules live in `SKILL.md` and `references/install-workflow.md`. Highlights: updates-only (never first-install), verify bundle ID before rsync, MCP-reported path as deploy destination (never hardcoded), interactive-only, one plugin at a time, disabled plugins skipped.

--- a/skills/update-plugins/SKILL.md
+++ b/skills/update-plugins/SKILL.md
@@ -32,7 +32,7 @@ Follow all phases in order. The `/indigo:update-plugins` command file summarises
 
 ### Phase 1 — DISCOVER
 
-```
+```text
 mcp__indigo__list_plugins
 ```
 
@@ -52,7 +52,7 @@ Parallelise heavily. GitHub calls are independent; do them concurrently via suba
 
 The cache file lives at `~/.claude/indigo-plugin-store-cache.json`. This is a generic user path — **do not** hardcode to a specific workspace or user directory. Use `$HOME`.
 
-Cache schema:
+Cache schema (example):
 
 ```json
 {
@@ -86,7 +86,7 @@ For each plugin with a resolved upstream, parse both version strings. Prefer `pa
 
 Produce a grouped report:
 
-```
+```markdown
 ## Upgrades available
 
 | Plugin | Bundle ID | Installed → Latest | Source | Release Notes |
@@ -135,7 +135,7 @@ Record per-plugin status and continue to the next. Only halt on systemic failure
 
 ### Phase 7 — SUMMARY
 
-```
+```markdown
 ## Update summary
 
 **Upgraded** (3):

--- a/skills/update-plugins/SKILL.md
+++ b/skills/update-plugins/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: update-plugins
+description: >-
+  This skill should be used when the user asks to "check for plugin updates",
+  "update Indigo plugins", "bulk update plugins", "check which plugins are out
+  of date", "upgrade plugins", "update all plugins", or similar bulk plugin
+  maintenance tasks on an Indigo home automation server. Discovers installed
+  plugins via MCP, finds upgrade candidates from GitHub releases or the Indigo
+  plugin store, previews a diff, and applies upgrades with confirmation.
+match:
+  - "**/.claude/indigo-plugin-store-cache.json"
+---
+
+# Indigo Plugin Bulk Updater
+
+Checks every installed Indigo plugin against its upstream source, reports which are out of date, and — with user confirmation — downloads and deploys upgrades.
+
+This skill is the detailed reference that the `/indigo:update-plugins` command loads. It is designed to be used **interactively** — the user always sees the diff before anything is written to disk.
+
+## Core Concepts
+
+- **MCP as source of truth for installed state**. Use `mcp__indigo__list_plugins` to enumerate plugins; use `mcp__indigo__get_plugin_by_id` for post-upgrade verification. The MCP returns the canonical bundle path, so no path needs to be hardcoded — the command works on any Indigo install, not just the author's.
+- **Two upstream sources, in priority order**: GitHub releases (preferred, clean API) → Indigo plugin store (fallback, HTML scraping).
+- **Bundle identifier is the match key**. `CFBundleIdentifier` from the plugin's `Info.plist` is always reliable. Don't match on display name — names drift and collide.
+- **`Info.plist` `GithubInfo`** is an Indigo-documented convention for plugins hosted on GitHub. When present, it gives us the repo coordinates with zero guessing.
+- **Updates only**. This skill never installs a plugin that isn't already present. First installs must go through Indigo's UI per workspace convention.
+- **Check → confirm → apply** is the only flow. No silent or batched automation in v1.
+
+## Workflow
+
+Follow all phases in order. The `/indigo:update-plugins` command file summarises these — this doc is the detailed version when something isn't obvious.
+
+### Phase 1 — DISCOVER
+
+```
+mcp__indigo__list_plugins
+```
+
+Capture `id`, `displayName`, `version`, `path`, `enabled` for each plugin. Include disabled plugins — the user may want to update them too, even if they're currently off.
+
+### Phase 2 — RESOLVE UPGRADE SOURCE
+
+For each plugin, consult `references/discovery.md`. The short version:
+
+1. **Try GitHub** — read `<path>/Contents/Info.plist`, look for `GithubInfo.GithubUser` and `GithubInfo.GithubRepo`. If both present, query `gh api /repos/<user>/<repo>/releases/latest` and record `tag_name`, `assets[*].browser_download_url` for any `.indigoPlugin.zip` asset, `html_url`.
+2. **Try store** — if no GithubInfo, look up the bundle ID in the store cache (Phase 3). If the cache was built from scraped detail pages, the entry already holds everything needed.
+3. **Unresolved** — record the plugin but continue processing others.
+
+Parallelise heavily. GitHub calls are independent; do them concurrently via subagents or background bash.
+
+### Phase 3 — MAINTAIN STORE CACHE
+
+The cache file lives at `~/.claude/indigo-plugin-store-cache.json`. This is a generic user path — **do not** hardcode to a specific workspace or user directory. Use `$HOME`.
+
+Cache schema:
+
+```json
+{
+  "fetched_at": "2026-04-15T12:00:00Z",
+  "listing_etag": "...",
+  "plugins": {
+    "pro.sleepers.indigoplugin.8channel-relay": {
+      "name": "8 Channel Network Relay",
+      "latest_version": "2.0.1",
+      "detail_url": "https://www.indigodomo.com/pluginstore/196/",
+      "download_url": "https://github.com/IndigoDomotics/indigo-8channel-relay/releases/download/v2.0.1/8chRelay.indigoPlugin.zip",
+      "github_url": "https://github.com/IndigoDomotics/indigo-8channel-relay"
+    }
+  }
+}
+```
+
+Refresh when: file doesn't exist, is older than 24 hours, or the user explicitly requests a refresh.
+
+Refresh procedure:
+1. Fetch the store listing (see `references/store-scraping.md` for the URL pattern and parse rules)
+2. Extract plugin detail page URLs
+3. Fetch each detail page (parallelise, be polite — small inter-request delay)
+4. Parse the five required fields per `references/store-scraping.md`
+5. Run the parse self-test against one known-good reference plugin; abort cache rebuild if the HTML has drifted
+6. Write the cache atomically (write to a temp path, then `mv` into place)
+
+### Phase 4 — DIFF
+
+For each plugin with a resolved upstream, parse both version strings. Prefer `packaging.version.parse` when available; fall back to lexicographic compare if parsing raises. Strip leading `v`.
+
+Produce a grouped report:
+
+```
+## Upgrades available
+
+| Plugin | Bundle ID | Installed → Latest | Source | Release Notes |
+|--------|-----------|---------------------|--------|---------------|
+| ...    | ...       | 1.0.3 → 1.1.0       | github | <link>        |
+
+## Up to date
+
+| Plugin | Installed |
+|--------|-----------|
+
+## Unresolved (no upstream source found)
+
+| Plugin | Bundle ID | Notes |
+|--------|-----------|-------|
+```
+
+### Phase 5 — CONFIRM
+
+Print the report. Wait for the user. Accepted replies:
+
+- `all` — apply every row in the "Upgrades available" section
+- `all except foo` / `all except foo, bar` — apply all but the named exclusions (match on name OR bundle ID)
+- A single plugin name or bundle ID — apply that one
+- `none` / `no` / `stop` — exit cleanly with no changes
+
+Anything ambiguous → ask again. Never guess at consent.
+
+### Phase 6 — APPLY
+
+Follow `references/install-workflow.md` per plugin. Sequence summary:
+
+1. **Download** — `gh release download <tag> --repo <user>/<repo> --pattern '*.indigoPlugin.zip' --dir <tmp>` for GitHub, `curl -L -o <tmp>/bundle.zip <url>` for store
+2. **Stage** — `unzip` to a temp dir. Expect a single `<Name>.indigoPlugin` directory at the top level
+3. **Verify bundle identifier** — read the staged `Contents/Info.plist` `CFBundleIdentifier` and assert it equals the installed plugin's bundle ID. If mismatch, **abort this plugin** and log why. Do not rsync over a different bundle.
+4. **Verify version** — read the staged `PluginVersion` and assert it matches what the upstream source advertised. Mismatch is a warning but not a hard fail (the source may have updated between check and apply).
+5. **Deploy** — `rsync -av --delete <staged>/Contents/ <installed_path>/Contents/`. Use the `path` returned by `mcp__indigo__list_plugins` / `mcp__indigo__get_plugin_by_id` as the destination — never hardcode
+6. **Restart** — `mcp__indigo__restart_plugin(plugin_id=<bundle_id>)`
+7. **Verify startup** —
+   - Poll `mcp__indigo__get_plugin_by_id` until the returned version matches the new version (or 15s timeout)
+   - Fetch recent event log with `mcp__indigo__query_event_log` and look for a "Started plugin" line for this bundle ID within the last 30 seconds
+   - If the log shows error-level entries from this plugin during the window, treat as a failure
+8. **Cleanup** — remove the temp download and staging dirs
+
+Record per-plugin status and continue to the next. Only halt on systemic failures (filesystem unwritable, MCP unreachable, network totally dead).
+
+### Phase 7 — SUMMARY
+
+```
+## Update summary
+
+**Upgraded** (3):
+- Netro Smart Sprinklers: 2026.1.3 → 2026.4.1
+- 8 Channel Network Relay: 2.0.0 → 2.0.1
+- ...
+
+**Failed** (1):
+- Foo Plugin: verification failed — bundle ID mismatch in downloaded asset
+
+**Unresolved** (2):
+- Custom Plugin X: no GithubInfo, not found in store
+- Legacy Plugin Y: no upstream source
+```
+
+For failures, include a one-line manual recovery hint (e.g. "download manually from <url> and install via Indigo UI").
+
+## Safety Rules
+
+- **Never** install a plugin that isn't already present. If the bundle ID isn't in the MCP's list, it's not a candidate.
+- **Always verify bundle ID** on the staged download before `rsync`. A wrong-bundle substitution would silently replace a different plugin.
+- **Use the MCP-reported `path`** for the destination. Do not hardcode `/Library/Application Support/Perceptive Automation/...` — let the MCP tell you where the plugin lives.
+- **Interactive only**. No automation hooks, no cron, no silent apply. The user always sees the report and confirms.
+- **One plugin at a time** during the apply phase, so a failure in one doesn't block the others or leave the Indigo server mid-restart on a known-good upgrade.
+
+## Related Skills
+
+- **`/indigo:dev`** — Indigo SDK plugin development reference. Useful if the user wants to understand what's inside a plugin bundle before trusting an upgrade.
+- **`/indigo:api`** — Indigo REST/WebSocket API reference. Not directly used here but helpful if the verification phase needs to confirm plugin-specific endpoints came up.

--- a/skills/update-plugins/SKILL.md
+++ b/skills/update-plugins/SKILL.md
@@ -7,52 +7,35 @@ description: >-
   maintenance tasks on an Indigo home automation server. Discovers installed
   plugins via MCP, finds upgrade candidates from GitHub releases or the Indigo
   plugin store, previews a diff, and applies upgrades with confirmation.
-match:
-  - "**/.claude/indigo-plugin-store-cache.json"
 ---
 
 # Indigo Plugin Bulk Updater
 
-Checks every installed Indigo plugin against its upstream source, reports which are out of date, and — with user confirmation — downloads and deploys upgrades.
+Checks every installed Indigo plugin against its upstream source, reports which are out of date, and — with user confirmation — downloads and deploys upgrades. Interactive only.
 
-This skill is the detailed reference that the `/indigo:update-plugins` command loads. It is designed to be used **interactively** — the user always sees the diff before anything is written to disk.
-
-## Core Concepts
-
-- **MCP as source of truth for installed state**. Use `mcp__indigo__list_plugins` to enumerate plugins; use `mcp__indigo__get_plugin_by_id` for post-upgrade verification. The MCP returns the canonical bundle path, so no path needs to be hardcoded — the command works on any Indigo install, not just the author's.
-- **Two upstream sources, in priority order**: GitHub releases (preferred, clean API) → Indigo plugin store (fallback, HTML scraping).
-- **Bundle identifier is the match key**. `CFBundleIdentifier` from the plugin's `Info.plist` is always reliable. Don't match on display name — names drift and collide.
-- **`Info.plist` `GithubInfo`** is an Indigo-documented convention for plugins hosted on GitHub. When present, it gives us the repo coordinates with zero guessing.
-- **Updates only**. This skill never installs a plugin that isn't already present. First installs must go through Indigo's UI per workspace convention.
-- **Check → confirm → apply** is the only flow. No silent or batched automation in v1.
+This skill is loaded by the `/indigo:update-plugins` command. The reference files under `references/` hold the detailed logic — this doc is the top-level workflow.
 
 ## Workflow
 
-Follow all phases in order. The `/indigo:update-plugins` command file summarises these — this doc is the detailed version when something isn't obvious.
-
 ### Phase 1 — DISCOVER
 
-```text
-mcp__indigo__list_plugins
-```
+Call `mcp__indigo__list_plugins` (default `include_disabled=false`). For each returned entry, capture `id`, `name`, `version`, `enabled`, `path`.
 
-Capture `id`, `displayName`, `version`, `path`, `enabled` for each plugin. Include disabled plugins — the user may want to update them too, even if they're currently off.
+**Disabled plugins are intentionally not candidates.** `list_plugins` with its default parameter excludes them, which is what we want — restarting a disabled plugin via `restart_plugin` could re-enable it unexpectedly. If the user wants to update a disabled plugin, tell them to enable it in Indigo first, then re-run.
 
 ### Phase 2 — RESOLVE UPGRADE SOURCE
 
-For each plugin, consult `references/discovery.md`. The short version:
+For each plugin, see `references/discovery.md`. Short version:
 
-1. **Try GitHub** — read `<path>/Contents/Info.plist`, look for `GithubInfo.GithubUser` and `GithubInfo.GithubRepo`. If both present, query `gh api /repos/<user>/<repo>/releases/latest` and record `tag_name`, `assets[*].browser_download_url` for any `.indigoPlugin.zip` asset, `html_url`.
-2. **Try store** — if no GithubInfo, look up the bundle ID in the store cache (Phase 3). If the cache was built from scraped detail pages, the entry already holds everything needed.
-3. **Unresolved** — record the plugin but continue processing others.
+1. **Try GitHub** — read `<path>/Contents/Info.plist` for `GithubInfo.GithubUser` + `GithubInfo.GithubRepo`. If present → `gh api /repos/<user>/<repo>/releases/latest` → capture `tag_name`, `html_url`, and any asset ending in `.indigoPlugin.zip`.
+2. **Try store** — no GithubInfo → look up the bundle ID in the store cache (Phase 3).
+3. **Unresolved** — neither source resolves → record and continue.
 
-Parallelise heavily. GitHub calls are independent; do them concurrently via subagents or background bash.
+Parallelise. See `references/discovery.md` for the cap and concurrency notes.
 
 ### Phase 3 — MAINTAIN STORE CACHE
 
-The cache file lives at `~/.claude/indigo-plugin-store-cache.json`. This is a generic user path — **do not** hardcode to a specific workspace or user directory. Use `$HOME`.
-
-Cache schema (example):
+Cache at `$HOME/.claude/indigo-plugin-store-cache.json`. Schema:
 
 ```json
 {
@@ -70,19 +53,11 @@ Cache schema (example):
 }
 ```
 
-Refresh when: file doesn't exist, is older than 24 hours, or the user explicitly requests a refresh.
-
-Refresh procedure:
-1. Fetch the store listing (see `references/store-scraping.md` for the URL pattern and parse rules)
-2. Extract plugin detail page URLs
-3. Fetch each detail page (parallelise, be polite — small inter-request delay)
-4. Parse the five required fields per `references/store-scraping.md`
-5. Run the parse self-test against one known-good reference plugin; abort cache rebuild if the HTML has drifted
-6. Write the cache atomically (write to a temp path, then `mv` into place)
+Refresh when: file missing, older than 24h, or the user asks. Full refresh procedure, parse rules, and the self-test that guards against HTML drift: see `references/store-scraping.md`.
 
 ### Phase 4 — DIFF
 
-For each plugin with a resolved upstream, parse both version strings. Prefer `packaging.version.parse` when available; fall back to lexicographic compare if parsing raises. Strip leading `v`.
+For each plugin with a resolved upstream, compare installed version to latest. Strip a leading `v`. Prefer `python3 -c 'from packaging.version import parse as p; ...'` if Python is available in the runtime; otherwise split on `.` and compare numeric segments, falling back to string compare if a segment isn't an integer. `2026.4.1`, `1.0.3`, `v1.0-beta` should all work.
 
 Produce a grouped report:
 
@@ -91,7 +66,6 @@ Produce a grouped report:
 
 | Plugin | Bundle ID | Installed → Latest | Source | Release Notes |
 |--------|-----------|---------------------|--------|---------------|
-| ...    | ...       | 1.0.3 → 1.1.0       | github | <link>        |
 
 ## Up to date
 
@@ -108,60 +82,33 @@ Produce a grouped report:
 
 Print the report. Wait for the user. Accepted replies:
 
-- `all` — apply every row in the "Upgrades available" section
-- `all except foo` / `all except foo, bar` — apply all but the named exclusions (match on name OR bundle ID)
+- `all` — apply every row in "Upgrades available"
+- `all except foo` / `all except foo, bar` — apply all but the named exclusions (match on name or bundle ID)
 - A single plugin name or bundle ID — apply that one
-- `none` / `no` / `stop` — exit cleanly with no changes
+- `none` / `no` / `stop` — exit cleanly, no changes
 
-Anything ambiguous → ask again. Never guess at consent.
+Anything ambiguous → ask again.
 
 ### Phase 6 — APPLY
 
-Follow `references/install-workflow.md` per plugin. Sequence summary:
-
-1. **Download** — `gh release download <tag> --repo <user>/<repo> --pattern '*.indigoPlugin.zip' --dir <tmp>` for GitHub, `curl -L -o <tmp>/bundle.zip <url>` for store
-2. **Stage** — `unzip` to a temp dir. Expect a single `<Name>.indigoPlugin` directory at the top level
-3. **Verify bundle identifier** — read the staged `Contents/Info.plist` `CFBundleIdentifier` and assert it equals the installed plugin's bundle ID. If mismatch, **abort this plugin** and log why. Do not rsync over a different bundle.
-4. **Verify version** — read the staged `PluginVersion` and assert it matches what the upstream source advertised. Mismatch is a warning but not a hard fail (the source may have updated between check and apply).
-5. **Deploy** — `rsync -av --delete <staged>/Contents/ <installed_path>/Contents/`. Use the `path` returned by `mcp__indigo__list_plugins` / `mcp__indigo__get_plugin_by_id` as the destination — never hardcode
-6. **Restart** — `mcp__indigo__restart_plugin(plugin_id=<bundle_id>)`
-7. **Verify startup** —
-   - Poll `mcp__indigo__get_plugin_by_id` until the returned version matches the new version (or 15s timeout)
-   - Fetch recent event log with `mcp__indigo__query_event_log` and look for a "Started plugin" line for this bundle ID within the last 30 seconds
-   - If the log shows error-level entries from this plugin during the window, treat as a failure
-8. **Cleanup** — remove the temp download and staging dirs
-
-Record per-plugin status and continue to the next. Only halt on systemic failures (filesystem unwritable, MCP unreachable, network totally dead).
+Follow `references/install-workflow.md` per plugin, one at a time. That file is the authoritative sequence; do not reinvent it here.
 
 ### Phase 7 — SUMMARY
 
-```markdown
-## Update summary
-
-**Upgraded** (3):
-- Netro Smart Sprinklers: 2026.1.3 → 2026.4.1
-- 8 Channel Network Relay: 2.0.0 → 2.0.1
-- ...
-
-**Failed** (1):
-- Foo Plugin: verification failed — bundle ID mismatch in downloaded asset
-
-**Unresolved** (2):
-- Custom Plugin X: no GithubInfo, not found in store
-- Legacy Plugin Y: no upstream source
-```
-
-For failures, include a one-line manual recovery hint (e.g. "download manually from <url> and install via Indigo UI").
+Print three sections: **Upgraded** (name, old → new version), **Failed** (name, reason, one-line manual recovery hint), **Unresolved** (name, why no source was found).
 
 ## Safety Rules
 
-- **Never** install a plugin that isn't already present. If the bundle ID isn't in the MCP's list, it's not a candidate.
-- **Always verify bundle ID** on the staged download before `rsync`. A wrong-bundle substitution would silently replace a different plugin.
-- **Use the MCP-reported `path`** for the destination. Do not hardcode `/Library/Application Support/Perceptive Automation/...` — let the MCP tell you where the plugin lives.
-- **Interactive only**. No automation hooks, no cron, no silent apply. The user always sees the report and confirms.
-- **One plugin at a time** during the apply phase, so a failure in one doesn't block the others or leave the Indigo server mid-restart on a known-good upgrade.
+The rules below are enforced by the phased instructions above and by the detailed sequence in `references/install-workflow.md`. They are listed here so a reader can audit them at a glance.
+
+- **Updates only.** Never install a plugin that isn't already returned by `mcp__indigo__list_plugins`. First installs go through Indigo's UI.
+- **Verify bundle ID before rsync.** Step 4 of the install workflow aborts the upgrade if the staged bundle's `CFBundleIdentifier` doesn't match the installed plugin.
+- **Deploy path comes from MCP.** Never hardcode `/Library/Application Support/...`. Read it from the `path` field returned by `list_plugins` / `get_plugin_by_id`.
+- **Interactive only.** No cron, no hooks, no silent apply. The user always sees the report and types confirmation.
+- **One plugin at a time.** Failures stay isolated; the Indigo server is never left mid-restart on a known-good upgrade.
+- **Disabled plugins are skipped.** See Phase 1.
 
 ## Related Skills
 
-- **`/indigo:dev`** — Indigo SDK plugin development reference. Useful if the user wants to understand what's inside a plugin bundle before trusting an upgrade.
-- **`/indigo:api`** — Indigo REST/WebSocket API reference. Not directly used here but helpful if the verification phase needs to confirm plugin-specific endpoints came up.
+- **`/indigo:dev`** — Indigo SDK plugin development reference. Useful to understand what's inside a plugin bundle before trusting an upgrade.
+- **`/indigo:api`** — Indigo REST/WebSocket API reference. Helpful if post-upgrade verification needs to confirm a plugin-specific endpoint came up.

--- a/skills/update-plugins/references/discovery.md
+++ b/skills/update-plugins/references/discovery.md
@@ -1,0 +1,90 @@
+# Upgrade Source Discovery
+
+How to find the upstream source for an installed Indigo plugin. Two sources, checked in priority order.
+
+## Source 1: GitHub releases (preferred)
+
+Indigo plugins that ship via GitHub embed a `GithubInfo` dict in `Contents/Info.plist`. This is a standard Indigo convention.
+
+**Example** (from `Netro Sprinklers.indigoPlugin/Contents/Info.plist`):
+
+```xml
+<key>GithubInfo</key>
+<dict>
+    <key>GithubRepo</key>
+    <string>netro-indigo</string>
+    <key>GithubUser</key>
+    <string>simons-plugins</string>
+</dict>
+```
+
+### Reading GithubInfo
+
+The bundle path comes from `mcp__indigo__list_plugins` (the `path` field). Read the Info.plist at `<path>/Contents/Info.plist`. macOS has `/usr/libexec/PlistBuddy` which is the cleanest way to extract a value:
+
+```bash
+PlistBuddy -c "Print :GithubInfo:GithubUser" "<path>/Contents/Info.plist" 2>/dev/null
+PlistBuddy -c "Print :GithubInfo:GithubRepo" "<path>/Contents/Info.plist" 2>/dev/null
+```
+
+If either command exits non-zero, the plugin doesn't declare a GitHub source — fall through to Source 2.
+
+### Querying GitHub
+
+```bash
+gh api /repos/<user>/<repo>/releases/latest
+```
+
+Capture from the JSON response:
+- `tag_name` — the release tag (strip leading `v` before comparing to installed version)
+- `name` — human-readable release name (fallback display)
+- `html_url` — the release page URL (use as release notes link)
+- `assets[*]` — list of release assets. Find the one whose `name` ends in `.indigoPlugin.zip`. Record its `browser_download_url`. If no such asset exists, treat the plugin as unresolved (the upstream exists but doesn't publish a downloadable bundle).
+
+### Rate limits
+
+GitHub's unauthenticated limit is 60 requests/hour. With 20-30 plugins per run and daily cache refresh, we're well under. If `gh` is configured (`gh auth status`), the limit is 5000/hour — effectively unlimited for this use case. Assume `gh` is available and authenticated.
+
+### Private repos
+
+If `gh api` returns 404 for a repo that the user knows exists, the repo is probably private and the user's GitHub token doesn't have access. Report the plugin as unresolved with a "private repository" hint.
+
+## Source 2: Indigo plugin store (fallback)
+
+For plugins with no `GithubInfo`, look up the bundle ID in the store cache. The cache is a pre-scraped `bundle_id → metadata` map maintained by Phase 3 of the main workflow. See `store-scraping.md` for the scrape rules.
+
+**If the bundle ID is in the cache:**
+- `latest_version` → compare against installed version
+- `download_url` → prefer this (often points to a GitHub release asset even for store-sourced plugins; in that case you're effectively using GitHub releases via the store as a directory)
+- `detail_url` → use as the release notes link
+
+**If the bundle ID is NOT in the cache:**
+- The plugin isn't listed on the Indigo store (private plugin, custom build, or publicly unlisted)
+- Mark as unresolved and continue
+
+## Source 3: Unresolved
+
+Record plugins with no upstream source. Report them at the end of the summary so the user knows which plugins aren't being tracked automatically. This is informational, not an error.
+
+Common reasons:
+- Plugin was sideloaded from a direct `.indigoPlugin.zip` download the user got privately
+- Plugin lives on GitHub but doesn't declare `GithubInfo` and isn't on the store
+- Plugin is from an author who distributes via their own website
+- Plugin is disabled and never fully set up
+
+For any of these, the manual remediation hint is: "check the plugin's documentation or contact the author for update instructions."
+
+## Parallelisation
+
+Phase 2 is per-plugin independent. For N installed plugins, Phase 2 is N potential network calls plus N Info.plist reads. Running them serially over 30 plugins can take 30+ seconds. Parallelise.
+
+Options (in order of preference):
+1. **Background bash**: launch `gh api` calls and Info.plist reads as background processes, collect results. Simple, effective, no external dependencies.
+2. **Subagents** (`dispatch-parallel-agents` skill): one subagent per plugin resolves its own source and returns the result. Good when the per-plugin logic has more than one step and the subagent can short-circuit on GitHub-found plugins.
+3. **Serial**: acceptable fallback for small plugin counts (<10) or when network is slow enough that parallelism adds little.
+
+Whichever you pick, cap concurrency at ~8-10 to avoid hammering GitHub or the user's network.
+
+## Caching per-plugin results
+
+In-memory only. Don't persist Phase 2 results across runs — GitHub releases change frequently and a stale per-plugin cache would produce wrong diffs. The store cache persists; per-plugin GitHub queries do not.

--- a/skills/update-plugins/references/discovery.md
+++ b/skills/update-plugins/references/discovery.md
@@ -1,12 +1,10 @@
 # Upgrade Source Discovery
 
-How to find the upstream source for an installed Indigo plugin. Two sources, checked in priority order.
+How to find the upstream source for an installed Indigo plugin. Sources are checked in priority order; fall through on miss.
 
-## Source 1: GitHub releases (preferred)
+## Source 1: `Info.plist` `GithubInfo` (preferred)
 
-Indigo plugins that ship via GitHub embed a `GithubInfo` dict in `Contents/Info.plist`. This is a standard Indigo convention.
-
-**Example** (from `Netro Sprinklers.indigoPlugin/Contents/Info.plist`):
+Indigo plugins that ship via GitHub embed a `GithubInfo` dict in `Contents/Info.plist`. Example:
 
 ```xml
 <key>GithubInfo</key>
@@ -20,71 +18,57 @@ Indigo plugins that ship via GitHub embed a `GithubInfo` dict in `Contents/Info.
 
 ### Reading GithubInfo
 
-The bundle path comes from `mcp__indigo__list_plugins` (the `path` field). Read the Info.plist at `<path>/Contents/Info.plist`. macOS has `/usr/libexec/PlistBuddy` which is the cleanest way to extract a value:
+The bundle path comes from `mcp__indigo__list_plugins` (the `path` field). Use the absolute `PlistBuddy` path so this works on any macOS without relying on `$PATH`:
 
 ```bash
-PlistBuddy -c "Print :GithubInfo:GithubUser" "<path>/Contents/Info.plist" 2>/dev/null
-PlistBuddy -c "Print :GithubInfo:GithubRepo" "<path>/Contents/Info.plist" 2>/dev/null
+/usr/libexec/PlistBuddy -c "Print :GithubInfo:GithubUser" "$PATH/Contents/Info.plist" 2>/dev/null
+/usr/libexec/PlistBuddy -c "Print :GithubInfo:GithubRepo" "$PATH/Contents/Info.plist" 2>/dev/null
 ```
 
-If either command exits non-zero, the plugin doesn't declare a GitHub source — fall through to Source 2.
+Non-zero exit → no GitHub source declared → fall through to Source 2.
 
 ### Querying GitHub
 
 ```bash
-gh api /repos/<user>/<repo>/releases/latest
+gh api /repos/$USER/$REPO/releases/latest
 ```
 
-Capture from the JSON response:
-- `tag_name` — the release tag (strip leading `v` before comparing to installed version)
-- `name` — human-readable release name (fallback display)
-- `html_url` — the release page URL (use as release notes link)
-- `assets[*]` — list of release assets. Find the one whose `name` ends in `.indigoPlugin.zip`. Record its `browser_download_url`. If no such asset exists, treat the plugin as unresolved (the upstream exists but doesn't publish a downloadable bundle).
+Capture:
+- `tag_name` — release tag (strip leading `v` before version compare)
+- `html_url` — release page, used as release notes link
+- `assets[*]` — find the entry whose `name` ends in `.indigoPlugin.zip`; record its `browser_download_url`. If no such asset exists, mark the plugin as unresolved (upstream exists but doesn't publish a downloadable bundle)
 
-### Rate limits
-
-GitHub's unauthenticated limit is 60 requests/hour. With 20-30 plugins per run and daily cache refresh, we're well under. If `gh` is configured (`gh auth status`), the limit is 5000/hour — effectively unlimited for this use case. Assume `gh` is available and authenticated.
-
-### Private repos
-
-If `gh api` returns 404 for a repo that the user knows exists, the repo is probably private and the user's GitHub token doesn't have access. Report the plugin as unresolved with a "private repository" hint.
+`gh api` returns 404 if the repo has no releases published yet, or if the repo is private and the user's token doesn't have access. Both cases → mark the plugin as unresolved with a short reason string so the user knows why.
 
 ## Source 2: Indigo plugin store (fallback)
 
-For plugins with no `GithubInfo`, look up the bundle ID in the store cache. The cache is a pre-scraped `bundle_id → metadata` map maintained by Phase 3 of the main workflow. See `store-scraping.md` for the scrape rules.
+For plugins with no `GithubInfo`, look up the bundle ID in the store cache. The cache is a pre-scraped `bundle_id → metadata` map built by Phase 3. See `store-scraping.md` for the scrape rules and the hard-earned caveats about what the store HTML actually exposes.
 
 **If the bundle ID is in the cache:**
-- `latest_version` → compare against installed version
-- `download_url` → prefer this (often points to a GitHub release asset even for store-sourced plugins; in that case you're effectively using GitHub releases via the store as a directory)
-- `detail_url` → use as the release notes link
+- `latest_version` → compare against installed
+- `download_url` → prefer this (often points at a GitHub release asset even for store-sourced plugins — you're effectively using GitHub releases with the store as a directory)
+- `detail_url` → release notes link
 
 **If the bundle ID is NOT in the cache:**
-- The plugin isn't listed on the Indigo store (private plugin, custom build, or publicly unlisted)
-- Mark as unresolved and continue
+- Plugin isn't listed on the store → mark unresolved, continue
 
 ## Source 3: Unresolved
 
-Record plugins with no upstream source. Report them at the end of the summary so the user knows which plugins aren't being tracked automatically. This is informational, not an error.
+Plugins with no upstream source. Informational only, not an error. Common reasons:
 
-Common reasons:
-- Plugin was sideloaded from a direct `.indigoPlugin.zip` download the user got privately
-- Plugin lives on GitHub but doesn't declare `GithubInfo` and isn't on the store
-- Plugin is from an author who distributes via their own website
-- Plugin is disabled and never fully set up
+- Sideloaded from a private `.indigoPlugin.zip`
+- Lives on GitHub but doesn't declare `GithubInfo` and isn't on the store
+- Author distributes via their own website
+- Plugin was never fully set up
 
-For any of these, the manual remediation hint is: "check the plugin's documentation or contact the author for update instructions."
+Manual remediation hint: "check the plugin's documentation or contact the author for update instructions."
 
 ## Parallelisation
 
-Phase 2 is per-plugin independent. For N installed plugins, Phase 2 is N potential network calls plus N Info.plist reads. Running them serially over 30 plugins can take 30+ seconds. Parallelise.
+Phase 2 is per-plugin independent. Run it concurrently with background bash — `gh api` calls and `PlistBuddy` reads are independent. Cap concurrency at ~8 to be polite to GitHub and the user's network. For small plugin counts (<10) serial is fine.
 
-Options (in order of preference):
-1. **Background bash**: launch `gh api` calls and Info.plist reads as background processes, collect results. Simple, effective, no external dependencies.
-2. **Subagents** (`dispatch-parallel-agents` skill): one subagent per plugin resolves its own source and returns the result. Good when the per-plugin logic has more than one step and the subagent can short-circuit on GitHub-found plugins.
-3. **Serial**: acceptable fallback for small plugin counts (<10) or when network is slow enough that parallelism adds little.
+Don't persist per-plugin Phase 2 results across runs — GitHub releases change and a stale per-plugin cache produces wrong diffs. The store cache persists; GitHub queries do not.
 
-Whichever you pick, cap concurrency at ~8-10 to avoid hammering GitHub or the user's network.
+## Future: shared source-of-truth catalog
 
-## Caching per-plugin results
-
-In-memory only. Don't persist Phase 2 results across runs — GitHub releases change frequently and a stale per-plugin cache would produce wrong diffs. The store cache persists; per-plugin GitHub queries do not.
+A shared `bundle_id → {user, repo}` mapping hosted in a public repo (e.g. as `plugin-source-registry.json` in `indigo-device-catalog`) could replace most of Source 2. The current store-scraping fallback is necessary only because some plugins on the Indigo store don't declare `GithubInfo` locally. A user-maintained catalog would let one person's scrape work benefit everyone, and would reduce store-page fetches to the long tail. Not implemented in v1.5.0; planned as a follow-up. When it lands, the resolution order becomes: local `GithubInfo` → shared catalog → store scrape → unresolved.

--- a/skills/update-plugins/references/install-workflow.md
+++ b/skills/update-plugins/references/install-workflow.md
@@ -1,0 +1,171 @@
+# Plugin Install Workflow
+
+The mechanical sequence for applying a single plugin upgrade. This is the most safety-critical part of the skill — it writes to the running Indigo install.
+
+## Prerequisites
+
+Before calling into this workflow for any plugin, the following must be true:
+- `mcp__indigo__list_plugins` has already returned an entry for the target bundle ID (we only update plugins that are already installed)
+- Phase 2 resolved an upstream source (GitHub or store) and captured a `download_url`
+- Phase 4 confirmed the installed version is strictly less than the advertised upstream version
+- Phase 5 — the user explicitly confirmed this specific plugin or "all"
+
+If any of those aren't true, this workflow must not run.
+
+## Why copying works for updates but not first installs
+
+Indigo installs a plugin the first time via a double-click in the Finder, which triggers the Indigo app to register the bundle with the server. Once registered, subsequent updates to that same bundle can be applied by overwriting the bundle contents in the `Plugins/` directory — no re-registration is needed. This is an explicit rule in the workspace CLAUDE.md and has been confirmed empirically with netro, reflector-logs, and others.
+
+**Consequence for this skill**: never create a new `<Name>.indigoPlugin/` directory that didn't exist before. If we're about to rsync into a path that doesn't already hold a registered plugin, stop and tell the user to install it manually via Indigo.
+
+## Step-by-step sequence
+
+### 1. Prepare temp dirs
+
+```bash
+TMPDIR=$(mktemp -d)
+DOWNLOAD_DIR="$TMPDIR/download"
+STAGE_DIR="$TMPDIR/stage"
+mkdir -p "$DOWNLOAD_DIR" "$STAGE_DIR"
+```
+
+Track `$TMPDIR` for cleanup in step 8 — always clean up, even on failure.
+
+### 2. Download the bundle
+
+**GitHub source:**
+
+```bash
+gh release download <tag> \
+    --repo <user>/<repo> \
+    --pattern '*.indigoPlugin.zip' \
+    --dir "$DOWNLOAD_DIR"
+```
+
+If `<tag>` is omitted, `gh` downloads the latest release. For this skill, pass the tag explicitly to guard against the release being updated mid-run.
+
+**Store source:**
+
+```bash
+curl -L -f -o "$DOWNLOAD_DIR/bundle.zip" <download_url>
+```
+
+Use `-f` so `curl` exits non-zero on HTTP errors (401/403/404/5xx). `-L` follows redirects — GitHub release asset URLs redirect through a CDN.
+
+Both paths must end with exactly one `.zip` file in `$DOWNLOAD_DIR`. Assert that and fail this plugin's upgrade otherwise.
+
+### 3. Unzip into staging
+
+```bash
+unzip -q -o "$DOWNLOAD_DIR"/*.zip -d "$STAGE_DIR"
+```
+
+Expect a single `<PluginName>.indigoPlugin/` directory at the top level of `$STAGE_DIR`. Find it:
+
+```bash
+STAGED_BUNDLE=$(find "$STAGE_DIR" -maxdepth 2 -name '*.indigoPlugin' -type d | head -1)
+```
+
+If nothing is found, or more than one bundle is present, fail this plugin's upgrade.
+
+### 4. Verify bundle identifier (critical safety check)
+
+```bash
+STAGED_BUNDLE_ID=$(/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$STAGED_BUNDLE/Contents/Info.plist")
+```
+
+Assert `STAGED_BUNDLE_ID == <expected bundle ID from MCP>`. If it doesn't match:
+
+- Log the mismatch at error level with both IDs
+- Do **not** proceed to rsync
+- Mark this plugin's upgrade as failed
+- Continue to the next plugin in the batch
+
+This check protects against wrong-bundle substitution — a scenario where a download URL points at a different plugin than expected (store misconfiguration, typo in the cache, malicious upstream, etc.). Without this check, rsync would happily replace a totally unrelated plugin's files.
+
+### 5. Verify version (soft check)
+
+```bash
+STAGED_VERSION=$(/usr/libexec/PlistBuddy -c "Print :PluginVersion" "$STAGED_BUNDLE/Contents/Info.plist")
+```
+
+Assert `STAGED_VERSION` matches what the upstream source advertised. If it doesn't:
+
+- Log a warning (the upstream may have published a new release between check and apply, which is fine)
+- Do not fail — continue to rsync
+
+The user will see the actual installed version in Phase 7.
+
+### 6. Deploy via rsync
+
+The destination is the `path` field from `mcp__indigo__list_plugins` / `mcp__indigo__get_plugin_by_id`. **Do not hardcode** a destination path — always use what MCP reports. This is what makes the skill portable across different Indigo installs.
+
+```bash
+rsync -av --delete "$STAGED_BUNDLE/Contents/" "<installed_path>/Contents/"
+```
+
+Notes:
+- Trailing slashes matter: `.../Contents/` → `.../Contents/` copies contents rather than nesting
+- `--delete` removes files present in the old bundle but not the new one — important for clean upgrades where a file was removed upstream
+- If rsync fails (permission denied, disk full, target not found), fail this plugin and continue
+
+**Do not try to sudo.** If rsync fails on permissions, the Indigo server isn't running under a user that owns the Plugins folder, and the user needs to resolve that themselves — don't escalate silently.
+
+### 7. Restart the plugin
+
+```
+mcp__indigo__restart_plugin(plugin_id=<bundle_id>)
+```
+
+### 8. Verify startup
+
+Two concurrent checks, both must pass within ~15 seconds:
+
+**Version check:**
+
+```
+mcp__indigo__get_plugin_by_id(plugin_id=<bundle_id>)
+```
+
+Keep polling until the returned version string matches the new upstream version (or a short timeout). Be lenient on exact match — Indigo's `version` field sometimes returns `CFBundleVersion` (e.g. `2.0.0`) rather than `PluginVersion`. If the field format is ambiguous, fall back to reading `<path>/Contents/Info.plist` directly and compare `PluginVersion`.
+
+**Log check:**
+
+```
+mcp__indigo__query_event_log(line_count=50)
+```
+
+Scan the entries for:
+- A recent `"Started plugin \"<displayName> <version>\""` line — success marker
+- Any `TypeStr` equal to the plugin's display name with `TypeVal` indicating error (1, 2, or 3) in the window since the restart — failure marker
+
+If the success marker is present and no errors are seen, mark this plugin's upgrade as successful.
+
+If errors appear, the upgrade rsync'd cleanly but the new code is misbehaving. Report the failure but **do not try to roll back** — rollback is out of scope for v1, and the user needs to decide whether to revert manually or fix the issue.
+
+### 9. Cleanup
+
+```bash
+rm -rf "$TMPDIR"
+```
+
+Always run this, even on failure, to avoid leaving stale temp dirs around.
+
+## What can go wrong
+
+| Failure mode | Where | Recovery |
+|--------------|-------|----------|
+| 404 downloading asset | Step 2 | Upstream release was deleted or URL changed; refresh store cache or recheck GitHub releases |
+| Zip has no `.indigoPlugin` directory | Step 3 | Treat as corrupted or wrong-artifact download; fail this plugin |
+| Bundle identifier mismatch | Step 4 | Cached metadata is wrong; don't rsync, fail this plugin, suggest manual inspection |
+| rsync permission denied | Step 6 | Indigo filesystem perms problem — user must resolve manually; continue with other plugins |
+| Plugin restart hangs | Step 7 | MCP `restart_plugin` has its own timeout; if it never returns, fall back to reporting "restart uncertain" and let the user check Indigo's UI |
+| Log shows errors after restart | Step 8 | Upgrade is applied but the new code doesn't work on this setup; mark failed, suggest the user check the plugin's release notes for config migration steps |
+
+## What must NOT happen
+
+- **No hardcoded paths.** Every destination comes from MCP. If the MCP call fails, the whole Phase 6 fails for that plugin — do not fall back to guessing.
+- **No downgrades.** If the user asks for a specific version that's older than installed, refuse and explain.
+- **No first installs.** If the target bundle doesn't already exist at `<installed_path>`, stop and tell the user to install via Indigo UI.
+- **No batched rsync.** Each plugin is handled and verified independently before moving to the next. This keeps failures isolated.
+- **No skipping the bundle-ID safety check.** It exists to prevent catastrophic wrong-bundle replacement.

--- a/skills/update-plugins/references/install-workflow.md
+++ b/skills/update-plugins/references/install-workflow.md
@@ -1,22 +1,18 @@
 # Plugin Install Workflow
 
-The mechanical sequence for applying a single plugin upgrade. This is the most safety-critical part of the skill — it writes to the running Indigo install.
+The mechanical sequence for applying a single plugin upgrade. Safety-critical — writes to the running Indigo install.
+
+First installs must go through Indigo's UI (double-click registers the bundle with the server). This workflow only handles updates to already-registered bundles: rsync over the existing `Contents/` and the Indigo server picks up the new code on restart.
 
 ## Prerequisites
 
-Before calling into this workflow for any plugin, the following must be true:
-- `mcp__indigo__list_plugins` has already returned an entry for the target bundle ID (we only update plugins that are already installed)
-- Phase 2 resolved an upstream source (GitHub or store) and captured a `download_url`
-- Phase 4 confirmed the installed version is strictly less than the advertised upstream version
-- Phase 5 — the user explicitly confirmed this specific plugin or "all"
+Before calling this workflow:
+- `mcp__indigo__list_plugins` has returned an entry for the target bundle ID (updates only)
+- Phase 2 resolved an upstream source (GitHub or store) with a `download_url`
+- Phase 4 confirmed installed version is strictly less than upstream
+- Phase 5 — user explicitly confirmed this plugin or `all`
 
-If any of those aren't true, this workflow must not run.
-
-## Why copying works for updates but not first installs
-
-Indigo installs a plugin the first time via a double-click in the Finder, which triggers the Indigo app to register the bundle with the server. Once registered, subsequent updates to that same bundle can be applied by overwriting the bundle contents in the `Plugins/` directory — no re-registration is needed. This is an explicit rule in the workspace CLAUDE.md and has been confirmed empirically with netro, reflector-logs, and others.
-
-**Consequence for this skill**: never create a new `<Name>.indigoPlugin/` directory that didn't exist before. If we're about to rsync into a path that doesn't already hold a registered plugin, stop and tell the user to install it manually via Indigo.
+If any of those aren't true, do not run.
 
 ## Step-by-step sequence
 
@@ -29,44 +25,46 @@ STAGE_DIR="$TMPDIR/stage"
 mkdir -p "$DOWNLOAD_DIR" "$STAGE_DIR"
 ```
 
-Track `$TMPDIR` for cleanup in step 8 — always clean up, even on failure.
+Track `$TMPDIR` for cleanup in step 9.
 
 ### 2. Download the bundle
 
 **GitHub source:**
 
 ```bash
-gh release download <tag> \
-    --repo <user>/<repo> \
+gh release download "$TAG" \
+    --repo "$USER/$REPO" \
     --pattern '*.indigoPlugin.zip' \
     --dir "$DOWNLOAD_DIR"
 ```
 
-If `<tag>` is omitted, `gh` downloads the latest release. For this skill, pass the tag explicitly to guard against the release being updated mid-run.
+Pass the tag explicitly (don't omit it) so the release can't be updated mid-run under our feet. Note: if the repo has no published releases, `gh api` in Phase 2 returns 404; the plugin should already have been classified as unresolved before we got here.
 
 **Store source:**
 
 ```bash
-curl -L -f -o "$DOWNLOAD_DIR/bundle.zip" <download_url>
+curl -L -f -o "$DOWNLOAD_DIR/bundle.zip" "$DOWNLOAD_URL"
 ```
 
-Use `-f` so `curl` exits non-zero on HTTP errors (401/403/404/5xx). `-L` follows redirects — GitHub release asset URLs redirect through a CDN.
+`-f` → exit non-zero on HTTP errors (401/403/404/5xx). `-L` → follow redirects (GitHub release assets redirect through a CDN).
 
-Both paths must end with exactly one `.zip` file in `$DOWNLOAD_DIR`. Assert that and fail this plugin's upgrade otherwise.
+Assert exactly one `.zip` landed in `$DOWNLOAD_DIR`:
+
+```bash
+ZIP_COUNT=$(find "$DOWNLOAD_DIR" -maxdepth 1 -name '*.zip' | wc -l | tr -d ' ')
+[ "$ZIP_COUNT" = "1" ] || { echo "expected 1 zip, got $ZIP_COUNT"; exit 1; }
+ZIP_PATH=$(find "$DOWNLOAD_DIR" -maxdepth 1 -name '*.zip' | head -1)
+```
 
 ### 3. Unzip into staging
 
 ```bash
-unzip -q -o "$DOWNLOAD_DIR"/*.zip -d "$STAGE_DIR"
-```
-
-Expect a single `<PluginName>.indigoPlugin/` directory at the top level of `$STAGE_DIR`. Find it:
-
-```bash
+unzip -q -o "$ZIP_PATH" -d "$STAGE_DIR"
 STAGED_BUNDLE=$(find "$STAGE_DIR" -maxdepth 1 -name '*.indigoPlugin' -type d | head -1)
+[ -n "$STAGED_BUNDLE" ] || { echo "no .indigoPlugin bundle in zip"; exit 1; }
 ```
 
-If nothing is found, or more than one bundle is present, fail this plugin's upgrade.
+If no bundle is found at the top level of `$STAGE_DIR`, fail this plugin — treat as a corrupted or wrong-artifact download.
 
 ### 4. Verify bundle identifier (critical safety check)
 
@@ -74,14 +72,14 @@ If nothing is found, or more than one bundle is present, fail this plugin's upgr
 STAGED_BUNDLE_ID=$(/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$STAGED_BUNDLE/Contents/Info.plist")
 ```
 
-Assert `STAGED_BUNDLE_ID == <expected bundle ID from MCP>`. If it doesn't match:
+Assert `STAGED_BUNDLE_ID == $EXPECTED_BUNDLE_ID` (from `mcp__indigo__list_plugins`). If it doesn't match:
 
-- Log the mismatch at error level with both IDs
-- Do **not** proceed to rsync
+- Log the mismatch with both IDs
+- Do **not** rsync
 - Mark this plugin's upgrade as failed
-- Continue to the next plugin in the batch
+- Continue to the next plugin
 
-This check protects against wrong-bundle substitution — a scenario where a download URL points at a different plugin than expected (store misconfiguration, typo in the cache, malicious upstream, etc.). Without this check, rsync would happily replace a totally unrelated plugin's files.
+This check guards against wrong-bundle substitution — a download URL pointing at a different plugin than expected (cache typo, store misconfiguration, upstream compromise). Without it, rsync would silently replace a totally unrelated plugin.
 
 ### 5. Verify version (soft check)
 
@@ -89,59 +87,54 @@ This check protects against wrong-bundle substitution — a scenario where a dow
 STAGED_VERSION=$(/usr/libexec/PlistBuddy -c "Print :PluginVersion" "$STAGED_BUNDLE/Contents/Info.plist")
 ```
 
-Assert `STAGED_VERSION` matches what the upstream source advertised. If it doesn't:
-
-- Log a warning (the upstream may have published a new release between check and apply, which is fine)
-- Do not fail — continue to rsync
-
-The user will see the actual installed version in Phase 7.
+Compare `STAGED_VERSION` to what the upstream source advertised. Mismatch → log a warning and continue (upstream may have published a new release between check and apply — not a hard fail). The final installed version shows up in Phase 7.
 
 ### 6. Deploy via rsync
 
-The destination is the `path` field from `mcp__indigo__list_plugins` / `mcp__indigo__get_plugin_by_id`. **Do not hardcode** a destination path — always use what MCP reports. This is what makes the skill portable across different Indigo installs.
+Destination is the `path` field from `mcp__indigo__list_plugins` or `mcp__indigo__get_plugin_by_id`. **Do not hardcode** — always read from MCP. This is what makes the skill portable across different Indigo installs.
 
 ```bash
-rsync -av --delete "$STAGED_BUNDLE/Contents/" "<installed_path>/Contents/"
+rsync -av --delete "$STAGED_BUNDLE/Contents/" "$INSTALLED_PATH/Contents/"
 ```
 
-Notes:
-- Trailing slashes matter: `.../Contents/` → `.../Contents/` copies contents rather than nesting
-- `--delete` removes files present in the old bundle but not the new one — important for clean upgrades where a file was removed upstream
-- If rsync fails (permission denied, disk full, target not found), fail this plugin and continue
+Trailing slashes matter: `.../Contents/` → `.../Contents/` copies contents rather than nesting. `--delete` removes files present in the old bundle but not the new one, so removed-upstream files don't linger.
 
-**Do not try to sudo.** If rsync fails on permissions, the Indigo server isn't running under a user that owns the Plugins folder, and the user needs to resolve that themselves — don't escalate silently.
+If rsync fails (permission denied, disk full, target not found), fail this plugin and continue. **Do not sudo.** If the user running this skill doesn't own the Plugins folder, the Indigo server is running as a different user and the permissions need to be resolved manually.
 
 ### 7. Restart the plugin
 
 ```text
-mcp__indigo__restart_plugin(plugin_id=<bundle_id>)
+mcp__indigo__restart_plugin(plugin_id=$BUNDLE_ID)
 ```
 
 ### 8. Verify startup
 
-Two concurrent checks, both must pass within ~15 seconds:
+Two checks. The **version check is the primary success signal**; the log check is a secondary sanity pass because the exact `TypeVal` severity mapping isn't well-documented and shouldn't be the sole oracle.
 
-**Version check:**
+**Version check (primary):**
 
 ```text
-mcp__indigo__get_plugin_by_id(plugin_id=<bundle_id>)
+mcp__indigo__get_plugin_by_id(plugin_id=$BUNDLE_ID)
 ```
 
-Keep polling until the returned version string matches the new upstream version (or a short timeout). Be lenient on exact match — Indigo's `version` field sometimes returns `CFBundleVersion` (e.g. `2.0.0`) rather than `PluginVersion`. If the field format is ambiguous, fall back to reading `<path>/Contents/Info.plist` directly and compare `PluginVersion`.
+Poll until the returned `version` field matches the new upstream version (with a ~15s timeout). Be lenient: `get_plugin_by_id` can return `CFBundleVersion` (e.g. `2.0.0`) rather than `PluginVersion` depending on the plugin. If there's ambiguity, read `$INSTALLED_PATH/Contents/Info.plist` directly via `/usr/libexec/PlistBuddy -c "Print :PluginVersion"` and compare.
 
-**Log check:**
+If the polled version never matches within the timeout → treat as a failed upgrade.
+
+**Log check (secondary):**
 
 ```text
 mcp__indigo__query_event_log(line_count=50)
 ```
 
-Scan the entries for:
-- A recent `"Started plugin \"<displayName> <version>\""` line — success marker
-- Any `TypeStr` equal to the plugin's display name with `TypeVal` indicating error (1, 2, or 3) in the window since the restart — failure marker
+Each entry has `Message`, `TypeVal`, `TypeStr`, `TimeStamp`. Scan for:
 
-If the success marker is present and no errors are seen, mark this plugin's upgrade as successful.
+- Success marker: a recent `Application`-type entry (`TypeStr="Application"`) with `Message` starting `"Started plugin \"<name> <version>\""` that references this bundle's display name
+- Potential failure: any entry whose `TypeStr` starts with `"Web Server Warning"` or contains the word `"Error"`, or any entry whose `TypeStr` matches the plugin's display name and whose message contains `error`/`exception`/`traceback`
 
-If errors appear, the upgrade rsync'd cleanly but the new code is misbehaving. Report the failure but **do not try to roll back** — rollback is out of scope for v1, and the user needs to decide whether to revert manually or fix the issue.
+Treat missing success marker as inconclusive, not failed, if the version check already passed. Treat a version-check failure as a failed upgrade regardless of what the log says.
+
+If the upgrade rsync'd cleanly but the new code throws errors after restart, report the failure. **Do not roll back** — rollback is out of scope for v1; let the user decide whether to revert.
 
 ### 9. Cleanup
 
@@ -149,23 +142,15 @@ If errors appear, the upgrade rsync'd cleanly but the new code is misbehaving. R
 rm -rf "$TMPDIR"
 ```
 
-Always run this, even on failure, to avoid leaving stale temp dirs around.
+Always run this, even on failure.
 
 ## What can go wrong
 
 | Failure mode | Where | Recovery |
 |--------------|-------|----------|
-| 404 downloading asset | Step 2 | Upstream release was deleted or URL changed; refresh store cache or recheck GitHub releases |
-| Zip has no `.indigoPlugin` directory | Step 3 | Treat as corrupted or wrong-artifact download; fail this plugin |
-| Bundle identifier mismatch | Step 4 | Cached metadata is wrong; don't rsync, fail this plugin, suggest manual inspection |
+| 404 downloading asset | Step 2 | Upstream release deleted or URL changed; refresh store cache or recheck GitHub releases |
+| Zip has no `.indigoPlugin` directory | Step 3 | Corrupted or wrong-artifact download; fail this plugin |
+| Bundle identifier mismatch | Step 4 | Cached metadata wrong; don't rsync, fail this plugin |
 | rsync permission denied | Step 6 | Indigo filesystem perms problem — user must resolve manually; continue with other plugins |
-| Plugin restart hangs | Step 7 | MCP `restart_plugin` has its own timeout; if it never returns, fall back to reporting "restart uncertain" and let the user check Indigo's UI |
-| Log shows errors after restart | Step 8 | Upgrade is applied but the new code doesn't work on this setup; mark failed, suggest the user check the plugin's release notes for config migration steps |
-
-## What must NOT happen
-
-- **No hardcoded paths.** Every destination comes from MCP. If the MCP call fails, the whole Phase 6 fails for that plugin — do not fall back to guessing.
-- **No downgrades.** If the user asks for a specific version that's older than installed, refuse and explain.
-- **No first installs.** If the target bundle doesn't already exist at `<installed_path>`, stop and tell the user to install via Indigo UI.
-- **No batched rsync.** Each plugin is handled and verified independently before moving to the next. This keeps failures isolated.
-- **No skipping the bundle-ID safety check.** It exists to prevent catastrophic wrong-bundle replacement.
+| Plugin restart hangs | Step 7 | MCP `restart_plugin` has its own timeout; if it never returns, report "restart uncertain" and let the user check Indigo's UI |
+| Log shows errors after restart | Step 8 | Upgrade is applied but new code misbehaves; mark failed, suggest checking release notes for config migration steps |

--- a/skills/update-plugins/references/install-workflow.md
+++ b/skills/update-plugins/references/install-workflow.md
@@ -63,7 +63,7 @@ unzip -q -o "$DOWNLOAD_DIR"/*.zip -d "$STAGE_DIR"
 Expect a single `<PluginName>.indigoPlugin/` directory at the top level of `$STAGE_DIR`. Find it:
 
 ```bash
-STAGED_BUNDLE=$(find "$STAGE_DIR" -maxdepth 2 -name '*.indigoPlugin' -type d | head -1)
+STAGED_BUNDLE=$(find "$STAGE_DIR" -maxdepth 1 -name '*.indigoPlugin' -type d | head -1)
 ```
 
 If nothing is found, or more than one bundle is present, fail this plugin's upgrade.
@@ -113,7 +113,7 @@ Notes:
 
 ### 7. Restart the plugin
 
-```
+```text
 mcp__indigo__restart_plugin(plugin_id=<bundle_id>)
 ```
 
@@ -123,7 +123,7 @@ Two concurrent checks, both must pass within ~15 seconds:
 
 **Version check:**
 
-```
+```text
 mcp__indigo__get_plugin_by_id(plugin_id=<bundle_id>)
 ```
 
@@ -131,7 +131,7 @@ Keep polling until the returned version string matches the new upstream version 
 
 **Log check:**
 
-```
+```text
 mcp__indigo__query_event_log(line_count=50)
 ```
 

--- a/skills/update-plugins/references/store-scraping.md
+++ b/skills/update-plugins/references/store-scraping.md
@@ -48,7 +48,7 @@ As of the initial implementation, the store uses static HTML that WebFetch reads
 
 Recommended anchors (to be refined empirically on first implementation):
 
-```
+```text
 Bundle identifier: text matching /Bundle Identifier[:\s]+([a-z0-9._-]+)/i
 Latest version:    text matching /Latest Version[:\s]+v?([0-9][0-9a-z.+\-]*)/i
 Download URL:      any <a href> ending in `.indigoPlugin.zip` or `.zip`

--- a/skills/update-plugins/references/store-scraping.md
+++ b/skills/update-plugins/references/store-scraping.md
@@ -1,52 +1,49 @@
 # Indigo Plugin Store Scraping
 
-How to extract plugin metadata from https://www.indigodomo.com/pluginstore/ when a plugin doesn't declare a GitHub source in its Info.plist.
+Last-resort fallback for plugins that don't declare `GithubInfo` in their Info.plist. Prefer Source 1 (local GithubInfo) whenever possible — see `discovery.md`.
 
-## Why scrape
+**Everything in this file is a hypothesis until verified against real store HTML.** The parse rules below are sketched from reading one sample detail page. They will need empirical refinement on first implementation, and the self-test at the end is designed to fail loudly if the HTML drifts away from what's documented here.
 
-The Indigo plugin store has no documented JSON/RSS/API feed. Detail pages are server-rendered static HTML — fully parseable with `WebFetch` without needing a JavaScript runtime. This is a pragmatic fallback only; **prefer GitHub releases when the plugin declares `GithubInfo`** (see `discovery.md`).
+## What the store does and doesn't guarantee
 
-## Fields to extract
+The Indigo plugin store has no documented JSON/RSS/API feed. Detail pages appear to be server-rendered static HTML readable by `WebFetch` without JavaScript.
 
-Every store detail page should expose these five fields. Extract them all when building the cache:
+The fields below are what we *hope* to extract. The one with the highest rot/availability risk is the **bundle identifier** — it is the match key for the whole fallback path, and it is not guaranteed to be rendered in human-readable form on every detail page. If a given plugin's detail page doesn't expose the bundle ID, we cannot match it to an installed plugin and the fallback collapses for that plugin.
 
-| Field | Purpose | Typical location |
-|-------|---------|------------------|
-| Bundle identifier | Match key — links store entry to installed plugin | Visible on the page as "Bundle Identifier: ..." text or data attribute |
-| Latest version | Compared against installed version | "Latest Version: vX.Y.Z" text |
-| Download URL | Target for `curl` in the apply phase | Anchor pointing at a `.zip` (often `github.com/.../releases/download/...`) |
-| GitHub URL | Optional source-code link, good release notes fallback | Anchor pointing at `github.com/<user>/<repo>` |
+## Fields to extract (hypothesised)
+
+| Field | Purpose | Availability |
+|-------|---------|--------------|
+| Bundle identifier | Match key against installed plugins | **Uncertain** — not visible on every store page; verify empirically |
+| Latest version | Version comparison | Likely visible as "Latest Version: vX.Y.Z" |
+| Download URL | Target for `curl` in apply phase | Anchor pointing at a `.zip` (often `github.com/.../releases/download/...`) |
+| GitHub URL | Release notes fallback | Anchor pointing at `github.com/<user>/<repo>` |
 | Plugin name + author | Display | Page heading + "Author: ..." text |
 
-If any of the first three are missing for a plugin you expected to find, treat that plugin as unresolved rather than trying to proceed with partial data.
+**If the bundle identifier isn't extractable for a plugin, skip it in the cache rather than persist a partial record.** Reporting no-upstream is better than wrong-upstream.
 
 ## Listing discovery
 
-The store doesn't publish a sitemap or API index, so we have to enumerate detail pages ourselves. Two viable strategies:
+The store doesn't publish a sitemap. Two strategies, try A first:
 
 ### Strategy A — Landing page crawl (preferred)
 
 1. Fetch `https://www.indigodomo.com/pluginstore/`
-2. Parse every anchor pointing at a detail page (URL pattern: `https://www.indigodomo.com/pluginstore/<N>/` where `<N>` is a small integer)
-3. Deduplicate and sort
-4. Fetch each detail page, parse, store in cache
-
-Pros: no enumeration gaps, no dependency on sequential IDs, robust to store deletions.
-Cons: landing page may not list every plugin if there's pagination or category navigation. Check for category/pagination links and follow them too.
+2. Parse anchors pointing at detail pages (URL pattern: `https://www.indigodomo.com/pluginstore/<N>/` where `<N>` is a small integer)
+3. Follow category/pagination links if present
+4. Deduplicate, fetch each detail page, parse, store in cache
 
 ### Strategy B — Sequential ID enumeration (fallback)
 
-If the landing page doesn't yield a full list, walk integer IDs from 1 upward until you see a run of consecutive 404s (say, 20 in a row). This is how a few home-automation communities discover scraped catalogs. Empirically the store has fewer than 500 plugins total, so this caps at a few hundred fetches.
+If the landing page demonstrably misses plugins: walk integer IDs from 1 upward until you hit a run of ~20 consecutive 404s. Don't run both strategies — it's wasted requests.
 
-Only use this if Strategy A demonstrably misses plugins. Don't use both unconditionally — it's wasted requests.
+## Parse rules (hypotheses — refine on first run)
 
-## Parse rules
+Keep all selectors in this one file. When the store HTML drifts, this should be the only file that needs updating.
 
-**Do not** hardcode CSS selectors in code scattered across the skill. Keep them all in this file. When the store HTML drifts, updating this file should be the only fix needed.
+Use defensive parsing: one CSS/structural selector and a regex fallback for each field, so a single DOM change doesn't take everything out at once.
 
-As of the initial implementation, the store uses static HTML that WebFetch reads without difficulty. Use defensive parsing: BeautifulSoup-style with specific selectors *and* a regex fallback for each field, so a single selector change doesn't break everything at once.
-
-Recommended anchors (to be refined empirically on first implementation):
+Starting anchors:
 
 ```text
 Bundle identifier: text matching /Bundle Identifier[:\s]+([a-z0-9._-]+)/i
@@ -57,33 +54,37 @@ Name:              <h1> or <title> text, stripped of the site suffix
 Author:            text matching /Author[:\s]+([^\n]+)/i
 ```
 
-If any field extraction returns None, log a warning with the detail page URL and skip that plugin in the cache (rather than persisting a partial record).
+If any field extraction returns None for a detail page, log a warning with the URL and skip that plugin.
 
 ## Parse self-test
 
-Before writing a freshly-built cache to disk, verify the parser still works against a known-good reference plugin. Pick one that has been on the store for a long time and is unlikely to disappear — e.g. **Indigo Domotics Hue Lights**. Fetch its detail page and assert all five required fields extract successfully.
+Before writing a freshly-built cache to disk, verify the parser still works against a pinned reference URL with pinned expected values. Use a URL, not just a plugin name — plugin names can be renamed or removed, but the detail URL + expected bundle ID are the actual contract:
 
-If the self-test fails:
-- Do not write the cache
-- Report to the user: "Indigo plugin store HTML has drifted — store-sourced upgrade detection is disabled until `references/store-scraping.md` is updated with fresh parse rules"
-- Continue with GitHub-sourced plugins (Phase 2 still works for those)
+- Reference URL: `https://www.indigodomo.com/pluginstore/196/`
+- Expected bundle ID: `pro.sleepers.indigoplugin.8channel-relay`
+- Expected name substring: `8 Channel`
 
-This prevents a silent rot where the scraper keeps producing empty results after a store redesign.
+Fetch the URL, run the parser, assert all five required fields extract and that bundle ID + name match. If any assertion fails:
+
+- Do **not** write the cache
+- Report: "Indigo plugin store HTML has drifted — store-sourced upgrade detection is disabled until `references/store-scraping.md` is updated with fresh parse rules"
+- Continue with Source 1 (GithubInfo-backed plugins still work)
+
+This guards against silent rot where the scraper keeps producing empty results after a store redesign.
 
 ## Politeness
 
-Scraping is unmetered by the store but good-citizen limits still apply:
 - Cap concurrent detail-page fetches at 4-6
 - Add a small inter-request delay (100-250ms) between batches
-- Set a descriptive User-Agent: `indigo-claude-plugin/<version> (update-plugins skill)`
-- Cache aggressively (24h by default) so a typical user hits the store at most once per day
+- User-Agent: `indigo-claude-plugin/<version> (update-plugins skill)`
+- Cache aggressively (24h default) so a typical user hits the store at most once per day
 
-## Download URLs from the store
+## Download URL preference
 
-Many store detail pages link their download directly to a GitHub release asset. When that's the case, use the GitHub URL as the `download_url` in the cache — it's stable, tagged, and often has a release notes page attached. Only fall back to store-hosted downloads when the store page doesn't offer a GitHub asset URL.
+When the store's download anchor already points at a GitHub release asset, use that URL directly — it's tagged, stable, and carries release notes. Only fall back to store-hosted downloads when no GitHub asset URL is linked.
 
 If the store's download URL is relative (e.g. `/pluginstore/download/...`), resolve it against `https://www.indigodomo.com/` before caching.
 
-## When the store is the wrong answer
+## Store older than installed
 
-If a plugin's store entry lists a version that is *older* than the installed version, that means the user is running a newer dev build or beta that isn't on the store yet. Report this as "installed is newer than store" and do not offer a downgrade. The user can manually revert if they want to.
+If the store lists an older version than what's installed, the user is running a dev/beta that isn't on the store yet. Report as "installed is newer than store" and do not offer a downgrade.

--- a/skills/update-plugins/references/store-scraping.md
+++ b/skills/update-plugins/references/store-scraping.md
@@ -1,0 +1,89 @@
+# Indigo Plugin Store Scraping
+
+How to extract plugin metadata from https://www.indigodomo.com/pluginstore/ when a plugin doesn't declare a GitHub source in its Info.plist.
+
+## Why scrape
+
+The Indigo plugin store has no documented JSON/RSS/API feed. Detail pages are server-rendered static HTML — fully parseable with `WebFetch` without needing a JavaScript runtime. This is a pragmatic fallback only; **prefer GitHub releases when the plugin declares `GithubInfo`** (see `discovery.md`).
+
+## Fields to extract
+
+Every store detail page should expose these five fields. Extract them all when building the cache:
+
+| Field | Purpose | Typical location |
+|-------|---------|------------------|
+| Bundle identifier | Match key — links store entry to installed plugin | Visible on the page as "Bundle Identifier: ..." text or data attribute |
+| Latest version | Compared against installed version | "Latest Version: vX.Y.Z" text |
+| Download URL | Target for `curl` in the apply phase | Anchor pointing at a `.zip` (often `github.com/.../releases/download/...`) |
+| GitHub URL | Optional source-code link, good release notes fallback | Anchor pointing at `github.com/<user>/<repo>` |
+| Plugin name + author | Display | Page heading + "Author: ..." text |
+
+If any of the first three are missing for a plugin you expected to find, treat that plugin as unresolved rather than trying to proceed with partial data.
+
+## Listing discovery
+
+The store doesn't publish a sitemap or API index, so we have to enumerate detail pages ourselves. Two viable strategies:
+
+### Strategy A — Landing page crawl (preferred)
+
+1. Fetch `https://www.indigodomo.com/pluginstore/`
+2. Parse every anchor pointing at a detail page (URL pattern: `https://www.indigodomo.com/pluginstore/<N>/` where `<N>` is a small integer)
+3. Deduplicate and sort
+4. Fetch each detail page, parse, store in cache
+
+Pros: no enumeration gaps, no dependency on sequential IDs, robust to store deletions.
+Cons: landing page may not list every plugin if there's pagination or category navigation. Check for category/pagination links and follow them too.
+
+### Strategy B — Sequential ID enumeration (fallback)
+
+If the landing page doesn't yield a full list, walk integer IDs from 1 upward until you see a run of consecutive 404s (say, 20 in a row). This is how a few home-automation communities discover scraped catalogs. Empirically the store has fewer than 500 plugins total, so this caps at a few hundred fetches.
+
+Only use this if Strategy A demonstrably misses plugins. Don't use both unconditionally — it's wasted requests.
+
+## Parse rules
+
+**Do not** hardcode CSS selectors in code scattered across the skill. Keep them all in this file. When the store HTML drifts, updating this file should be the only fix needed.
+
+As of the initial implementation, the store uses static HTML that WebFetch reads without difficulty. Use defensive parsing: BeautifulSoup-style with specific selectors *and* a regex fallback for each field, so a single selector change doesn't break everything at once.
+
+Recommended anchors (to be refined empirically on first implementation):
+
+```
+Bundle identifier: text matching /Bundle Identifier[:\s]+([a-z0-9._-]+)/i
+Latest version:    text matching /Latest Version[:\s]+v?([0-9][0-9a-z.+\-]*)/i
+Download URL:      any <a href> ending in `.indigoPlugin.zip` or `.zip`
+GitHub URL:        any <a href> matching `github.com/<user>/<repo>` (no trailing path)
+Name:              <h1> or <title> text, stripped of the site suffix
+Author:            text matching /Author[:\s]+([^\n]+)/i
+```
+
+If any field extraction returns None, log a warning with the detail page URL and skip that plugin in the cache (rather than persisting a partial record).
+
+## Parse self-test
+
+Before writing a freshly-built cache to disk, verify the parser still works against a known-good reference plugin. Pick one that has been on the store for a long time and is unlikely to disappear — e.g. **Indigo Domotics Hue Lights**. Fetch its detail page and assert all five required fields extract successfully.
+
+If the self-test fails:
+- Do not write the cache
+- Report to the user: "Indigo plugin store HTML has drifted — store-sourced upgrade detection is disabled until `references/store-scraping.md` is updated with fresh parse rules"
+- Continue with GitHub-sourced plugins (Phase 2 still works for those)
+
+This prevents a silent rot where the scraper keeps producing empty results after a store redesign.
+
+## Politeness
+
+Scraping is unmetered by the store but good-citizen limits still apply:
+- Cap concurrent detail-page fetches at 4-6
+- Add a small inter-request delay (100-250ms) between batches
+- Set a descriptive User-Agent: `indigo-claude-plugin/<version> (update-plugins skill)`
+- Cache aggressively (24h by default) so a typical user hits the store at most once per day
+
+## Download URLs from the store
+
+Many store detail pages link their download directly to a GitHub release asset. When that's the case, use the GitHub URL as the `download_url` in the cache — it's stable, tagged, and often has a release notes page attached. Only fall back to store-hosted downloads when the store page doesn't offer a GitHub asset URL.
+
+If the store's download URL is relative (e.g. `/pluginstore/download/...`), resolve it against `https://www.indigodomo.com/` before caching.
+
+## When the store is the wrong answer
+
+If a plugin's store entry lists a version that is *older* than the installed version, that means the user is running a newer dev build or beta that isn't on the store yet. Report this as "installed is newer than store" and do not offer a downgrade. The user can manually revert if they want to.


### PR DESCRIPTION
## Summary

- Adds a new `/indigo:update-plugins` slash command that discovers every installed Indigo plugin via MCP, finds upgrade candidates from GitHub releases (via `Info.plist` `GithubInfo`) or the Indigo plugin store (HTML scraping fallback), previews the diff, and deploys upgrades with user confirmation.
- Generic: works for any user of the marketplace. Destinations come from the `path` field returned by `mcp__indigo__list_plugins` rather than any hardcoded deploy path, so there are no author-specific assumptions.
- Safety: verifies the staged bundle's `CFBundleIdentifier` matches the installed plugin before any `rsync`, protecting against wrong-bundle substitution. Never creates a new bundle (first installs still go through Indigo's UI). Always interactive.

## Files

- `commands/update-plugins.md` — slash command entry point
- `skills/update-plugins/SKILL.md` — phased workflow doc
- `skills/update-plugins/references/discovery.md` — GitHub-then-store resolution logic
- `skills/update-plugins/references/store-scraping.md` — parse rules for store detail pages, isolated so HTML drift can be fixed in one file
- `skills/update-plugins/references/install-workflow.md` — download → verify → rsync → restart → verify sequence
- Version bump `1.4.4 → 1.5.0` in both `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` (new user-facing command → minor bump)
- README updated to list `/indigo:html-pages` (was previously missing) and the new `/indigo:update-plugins`

## Test plan

- [ ] `/plugin marketplace update indigo-claude-plugin` loads 1.5.0 cleanly
- [ ] `/indigo:update-plugins` enumerates all installed plugins (no filtering)
- [ ] Plugins with `GithubInfo` in their Info.plist resolve via `gh api` path
- [ ] Plugins without `GithubInfo` resolve via store cache fallback
- [ ] Plugins on neither source are reported as "unresolved" at the bottom of the summary — not an error
- [ ] Dry-run (stop after Phase 5) produces a plausible report without writing to jarvis
- [ ] Live end-to-end against one safe plugin each from GitHub and store sources
- [ ] Bundle-ID mismatch in a staged download aborts that plugin's upgrade and continues to the next
- [ ] Second run within 24h uses the store cache and is noticeably faster
- [ ] Store parse self-test fails loudly if the reference plugin can't be parsed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Plugin version bumped to 1.5.0

* **New Features**
  * /indigo:html-pages — build self-contained HTML dashboards with live device controls
  * /indigo:update-plugins — interactive bulk updater to detect and apply plugin upgrades with explicit confirmation

* **Documentation**
  * Added comprehensive docs: discovery/resolution, install workflow, store scraping, caching, diff/reporting, safety rules, and interactive upgrade guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->