### PR TITLE
feat: bundled plugin source registry (208 plugins)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "indigo",
       "source": "./",
       "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "repository": "https://github.com/simons-plugins/indigo-claude-plugin",
       "license": "MIT",
       "keywords": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "indigo",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
   "repository": "https://github.com/simons-plugins/indigo-claude-plugin"
 }

--- a/commands/update-plugins.md
+++ b/commands/update-plugins.md
@@ -43,20 +43,17 @@ Call `mcp__indigo__list_plugins` with its default parameters (disabled plugins a
 
 ### Phase 2 — RESOLVE UPGRADE SOURCE
 
-For each installed plugin, determine where to check for updates. See `references/discovery.md` for the full logic. Summary:
+For each installed plugin, determine where to check for updates. See `references/discovery.md` for the full logic. Summary (three sources in priority order):
 
-1. Read `<path>/Contents/Info.plist` via `/usr/libexec/PlistBuddy` and look for a `GithubInfo` dict with `GithubUser` + `GithubRepo` keys.
-2. If present → source is **GitHub**. Query `gh api /repos/<user>/<repo>/releases/latest`.
-3. If absent → source is **store**. Look up the bundle ID in the store cache (Phase 3).
-4. If neither yields a result → source is **unresolved**.
+1. **Local `GithubInfo`** — read `<path>/Contents/Info.plist` via `/usr/libexec/PlistBuddy`. If `GithubInfo.GithubUser` + `GithubInfo.GithubRepo` are present → query `gh api /repos/<user>/<repo>/releases/latest`.
+2. **Bundled registry** — look up the bundle ID in `$CLAUDE_PLUGIN_ROOT/data/plugin-source-registry.json`. Entries have either a `github` slug (→ GitHub releases) or a `store_url` (→ fetch the store detail page for version + download). No runtime scraping for plugins in the registry.
+3. **Store scraping fallback** — for plugins in neither Info.plist nor the registry. See `references/store-scraping.md`. Rare; suggest a PR adding the plugin to the registry when it triggers.
+
+If none resolve → mark unresolved and continue.
 
 Parallelise across plugins — a 30-plugin serial pass over the network is painfully slow.
 
-### Phase 3 — MAINTAIN STORE CACHE
-
-Cache lives at `$HOME/.claude/indigo-plugin-store-cache.json`. Refresh when missing, older than 24 hours, or on user request. Before trusting a freshly refreshed cache, run the parse self-test in `references/store-scraping.md` — if the HTML has drifted, bail with a clear error rather than silently producing wrong results.
-
-### Phase 4 — DIFF
+### Phase 3 — DIFF
 
 For every plugin with a resolved source, compare installed version to latest. Strip leading `v`. Prefer `python3 -c 'from packaging.version import parse as p; ...'` when Python is available; fall back to split-on-`.` numeric-or-string segment compare. Handles `2026.4.1`, `1.0.3`, and `v1.0-beta`.
 
@@ -66,7 +63,7 @@ Build an upgrade report grouped into three sections:
 - **Up to date** — informational
 - **Unresolved** — plugins where no upstream source was found (bottom of the report, never an error)
 
-### Phase 5 — CONFIRM
+### Phase 4 — CONFIRM
 
 Render the report. Wait for explicit user go-ahead. Accept:
 
@@ -77,13 +74,13 @@ Render the report. Wait for explicit user go-ahead. Accept:
 
 Do not interpret ambiguous replies as consent. When in doubt, ask again.
 
-### Phase 6 — APPLY (per plugin, one at a time)
+### Phase 5 — APPLY (per plugin, one at a time)
 
 Follow `references/install-workflow.md` for the exact sequence. Every step — download, unzip-before-copy, verify bundle ID, rsync over the installed `Contents/`, restart via MCP, verify startup — is documented there with the commands to run. Don't reinvent the sequence here.
 
 Report pass/fail per plugin. On failure of one plugin, continue to the next — don't halt the whole batch unless the failure indicates something systemic (filesystem unwritable, MCP unreachable, network dead).
 
-### Phase 7 — SUMMARY
+### Phase 6 — SUMMARY
 
 Report three sections:
 

--- a/data/plugin-source-registry.json
+++ b/data/plugin-source-registry.json
@@ -1,0 +1,860 @@
+{
+  "updated_at": "2026-04-15",
+  "note": "Static bundle_id \u2192 upstream map for Indigo plugins. Entries with `github` point at a github.com/user/repo slug (preferred upstream \u2014 use GitHub releases). Entries with `store_url` are Indigo store-hosted; the skill must fetch the store detail page at runtime to get the latest version and download URL.",
+  "source": "Scraped from https://www.indigodomo.com/pluginstore/ detail pages on 2026-04-15. Contribute additions or corrections via PR to simons-plugins/indigo-claude-plugin.",
+  "plugins": {
+    "com.GlennNZ.indigoplugin.ActronQUE": {
+      "name": "Actron QUE AC",
+      "github": "ghawken/ActronQue-IndigoPlugin"
+    },
+    "com.GlennNZ.indigoplugin.BlueIris": {
+      "name": "BlueIris Plugin",
+      "github": "ghawken/IndigoPlugin-BlueIris"
+    },
+    "com.GlennNZ.indigoplugin.DeepQuestAI": {
+      "name": "DeepQuestAI Plugin",
+      "github": "ghawken/DeepQuestAI"
+    },
+    "com.GlennNZ.indigoplugin.ESPhome4indigo": {
+      "name": "ESPHome Indigo Plugin",
+      "github": "ghawken/ESPHome_IndigoPlugin"
+    },
+    "com.GlennNZ.indigoplugin.EmbyPlugin": {
+      "name": "Emby Plugin",
+      "github": "ghawken/EmbyPlugin.indigoPlugin"
+    },
+    "com.GlennNZ.indigoplugin.EnphaseEnvoy": {
+      "name": "Enphase Envoy Plugin",
+      "github": "Ghawken/IndigoEnphaseEnvoy"
+    },
+    "com.GlennNZ.indigoplugin.FindFriendsMini": {
+      "name": "FindFriendsMini",
+      "github": "ghawken/IndigoPlugin-iFindFriendMini"
+    },
+    "com.GlennNZ.indigoplugin.HomeKitLink-Siri": {
+      "name": "HomeKitLink Siri",
+      "github": "Ghawken/HomeKitLink-Siri"
+    },
+    "com.GlennNZ.indigoplugin.ParadoxAlarm": {
+      "name": "Paradox Alarm",
+      "github": "ghawken/SpectrumIndigo"
+    },
+    "com.GlennNZ.indigoplugin.SimpleLED": {
+      "name": "LED Simple Effects",
+      "github": "ghawken/Indigo-SimpleLED"
+    },
+    "com.GlennNZ.indigoplugin.SolarSmart": {
+      "name": "SolarSmart",
+      "github": "ghawken/SolarSmartPlugin"
+    },
+    "com.GlennNZ.indigoplugin.SunRise": {
+      "name": "SunRise Device Plugin",
+      "github": "ghawken/Indigo-Sunrise-Plugin"
+    },
+    "com.GlennNZ.indigoplugin.TeslaBattery": {
+      "name": "Tesla Battery",
+      "github": "ghawken/TeslaBatteryPlugin"
+    },
+    "com.GlennNZ.indigoplugin.WinRemote": {
+      "name": "WinRemote Plugin",
+      "github": "Ghawken/IndigoPlugin-WinRemote"
+    },
+    "com.GlennNZ.indigoplugin.appleTV": {
+      "name": "appleTV Plugin",
+      "github": "Ghawken/appleTV-indigoPlugin"
+    },
+    "com.GlennNZ.indigoplugin.deluxeGraphing": {
+      "name": "Deluxe Graphing",
+      "github": "ghawken/DeluxeGraphing"
+    },
+    "com.GlennNZ.indigoplugin.device-timer": {
+      "name": "Device Timer",
+      "github": "ghawken/Device_Timer_Plugin"
+    },
+    "com.GlennNZ.indigoplugin.dreame_vacuum": {
+      "name": "Dreame Vacuum Plugin",
+      "github": "ghawken/Dreame-Indigo"
+    },
+    "com.GlennNZ.indigoplugin.evsemaster": {
+      "name": "EVSE Master Charger",
+      "github": "ghawken/EVSEMaster-Plugin"
+    },
+    "com.GlennNZ.indigoplugin.geckoSpa": {
+      "name": "Gecko inTouch Spa Plugin",
+      "github": "ghawken/Indigo-GeckoSPA"
+    },
+    "com.GlennNZ.indigoplugin.holiday": {
+      "name": "Holiday",
+      "github": "Ghawken/Holiday"
+    },
+    "com.GlennNZ.indigoplugin.iMessage": {
+      "name": "iMessage Plugin",
+      "github": "Ghawken/iMessagePlugin"
+    },
+    "com.GlennNZ.indigoplugin.irobot": {
+      "name": "iRobot-Roomba",
+      "github": "ghawken/Indigo-iRobotRoomba"
+    },
+    "com.GlennNZ.indigoplugin.mammotion": {
+      "name": "Mammotion Mower",
+      "github": "ghawken/MammotionPlugin"
+    },
+    "com.JohnBurgess.indigoplugin.TP-Link-Device": {
+      "name": "TP-Link Device",
+      "github": "jtburgess/indigo-TP-Link"
+    },
+    "com.anyone.indigoplugin.apc-pdu-control": {
+      "name": "APC PDU Control",
+      "github": "anyone2/IndigoPlugin-APC-PDU-Control"
+    },
+    "com.anyone.indigoplugin.voice-monkey": {
+      "name": "Voice Monkey",
+      "github": "anyone2/IndigoPlugin-Voice-Monkey"
+    },
+    "com.autologplugin.awtrix3": {
+      "name": "AWTRIX 3",
+      "github": "autolog/AWTRIX"
+    },
+    "com.autologplugin.indigoplugin.dynamicviewcontroller": {
+      "name": "Dynamic View Controller",
+      "github": "autolog/Dynamic_View_Controller"
+    },
+    "com.autologplugin.indigoplugin.foscamhdcontroller": {
+      "name": "Foscam HD Controller",
+      "github": "autolog/Foscam_HD_Controller"
+    },
+    "com.autologplugin.indigoplugin.hubitat": {
+      "name": "Hubitat Bridge",
+      "github": "Autolog/Hubitat_Bridge"
+    },
+    "com.autologplugin.indigoplugin.lifxcontroller": {
+      "name": "LIFX",
+      "github": "autolog/LIFX_Controller"
+    },
+    "com.autologplugin.indigoplugin.nanoleafcontroller": {
+      "name": "Nanoleaf",
+      "github": "autolog/nanoleaf_Controller"
+    },
+    "com.autologplugin.indigoplugin.rooncontroller": {
+      "name": "Roon",
+      "github": "autolog/Roon_Controller"
+    },
+    "com.autologplugin.indigoplugin.smappeecontroller": {
+      "name": "Smappee",
+      "github": "autolog/Smappee"
+    },
+    "com.autologplugin.indigoplugin.starlingBridge": {
+      "name": "Starling Bridge",
+      "github": "autolog/Starling_Bridge"
+    },
+    "com.autologplugin.indigoplugin.trvcontroller": {
+      "name": "TRV",
+      "github": "autolog/TRV_Controller"
+    },
+    "com.autologplugin.indigoplugin.zigbee2mqtt": {
+      "name": "Zigbee2mqtt Bridge",
+      "github": "autolog/zigbee2mqtt_Bridge"
+    },
+    "com.autologplugin.indigoplugin.zwaveinterpreter": {
+      "name": "Z-Wave Interpreter",
+      "github": "autolog/Z-Wave_Interpreter"
+    },
+    "com.barn.indigoplugin.Daikin-Wifi": {
+      "name": "Daikin Wifi Controller",
+      "github": "neilkplugins/Daikin-Wifi-indigo-plugin"
+    },
+    "com.barn.indigoplugin.GlowmarktCAD": {
+      "name": "GlowmarktCAD",
+      "github": "neilkplugins/Glow-IHD-CAD-indigo-plugin"
+    },
+    "com.barn.indigoplugin.Honeywell_Evohome": {
+      "name": "Evohome",
+      "github": "neilkplugins/evohome-indigo-plugin"
+    },
+    "com.barn.indigoplugin.Solcast": {
+      "name": "Solcast",
+      "github": "neilkplugins/Solcast-indigo-plugin"
+    },
+    "com.barn.indigoplugin.VeluxActive": {
+      "name": "Velux Active",
+      "github": "neilkplugins/VeluxActive-indigo-plugin"
+    },
+    "com.barn.indigoplugin.WLED": {
+      "name": "WLED",
+      "github": "neilkplugins/WLED-indigo-plugin"
+    },
+    "com.berkinet.ad2usb": {
+      "name": "AD2USB Alarm Interface",
+      "github": "bla260/ad2usb"
+    },
+    "com.boisypitre.vss": {
+      "name": "VSS - Virtual Security System",
+      "github": "boisy/VSS"
+    },
+    "com.drjason.temp-adapter": {
+      "name": "Adapters",
+      "github": "IndigoDomotics/adapters"
+    },
+    "com.duncanware.daytonAudioController": {
+      "name": "Dayton Audio Controller",
+      "github": "RogueProeliator/indigo-plugins-dayton-audio"
+    },
+    "com.duncanware.domoPadMobileClient": {
+      "name": "Domotics Pad Mobile Client",
+      "github": "RogueProeliator/indigo-plugins-googleclients"
+    },
+    "com.duncanware.nilesAudioReceiver": {
+      "name": "Niles Audio Receiver Plugin",
+      "github": "RogueProeliator/indigo-plugins-nilesaudio"
+    },
+    "com.duncanware.onkyoNetworkRemote": {
+      "name": "Onkyo Network Remote Plugin",
+      "github": "RogueProeliator/indigo-plugins-onkyo-receiver"
+    },
+    "com.duncanware.plexMediaServerManager": {
+      "name": "Plex Media Server Manager",
+      "github": "RogueProeliator/indigo-plugins-plex-server-manager"
+    },
+    "com.duncanware.rokuNetworkRemote": {
+      "name": "Roku Network Remote",
+      "github": "RogueProeliator/indigo-plugins-roku"
+    },
+    "com.duncanware.sharpTvNetworkRemote": {
+      "name": "Sharp TV Network Remote Plugin",
+      "github": "RogueProeliator/IndigoPlugins-Sharp-TV-Network-Remote"
+    },
+    "com.durosity.indigoplugin.lighttools": {
+      "name": "LightTools",
+      "github": "durosity/Indigo-LightTools"
+    },
+    "com.durosity.indigoplugin.renault": {
+      "name": "Renault Car",
+      "github": "Durosity/Indigo-Renault-Car"
+    },
+    "com.flyingdiver.indigoplugin.bondhome": {
+      "name": "Bond Home",
+      "github": "FlyingDiver/Indigo-BondHome"
+    },
+    "com.flyingdiver.indigoplugin.camect": {
+      "name": "Camect",
+      "github": "FlyingDiver/Indigo-Camect"
+    },
+    "com.flyingdiver.indigoplugin.ecobee": {
+      "name": "Ecobee 2",
+      "github": "FlyingDiver/Indigo-Ecobee-2"
+    },
+    "com.flyingdiver.indigoplugin.fireboard": {
+      "name": "Fireboard",
+      "github": "FlyingDiver/Indigo-FireBoard"
+    },
+    "com.flyingdiver.indigoplugin.ftp": {
+      "name": "FTP",
+      "github": "FlyingDiver/Indigo-FTP"
+    },
+    "com.flyingdiver.indigoplugin.harmonyhub": {
+      "name": "Harmony Hub",
+      "github": "FlyingDiver/Indigo-Harmony"
+    },
+    "com.flyingdiver.indigoplugin.httpd2": {
+      "name": "HTTPd 2",
+      "github": "FlyingDiver/Indigo-HTTPd-2"
+    },
+    "com.flyingdiver.indigoplugin.lifxbridge": {
+      "name": "LIFX Bridge",
+      "github": "FlyingDiver/Indigo-lifx-bridge"
+    },
+    "com.flyingdiver.indigoplugin.lutron-leap": {
+      "name": "Lutron Leap",
+      "github": "FlyingDiver/Indigo-Lutron-Leap"
+    },
+    "com.flyingdiver.indigoplugin.masquerade": {
+      "name": "Masquerade",
+      "github": "FlyingDiver/Indigo-Masquerade"
+    },
+    "com.flyingdiver.indigoplugin.miniPurple": {
+      "name": "miniPurple",
+      "github": "FlyingDiver/Indigo-miniPurple"
+    },
+    "com.flyingdiver.indigoplugin.miniUniFi": {
+      "name": "miniUniFi",
+      "github": "FlyingDiver/Indigo-miniUniFi"
+    },
+    "com.flyingdiver.indigoplugin.miniserial": {
+      "name": "miniSerial",
+      "github": "FlyingDiver/Indigo-miniSerial"
+    },
+    "com.flyingdiver.indigoplugin.mqtt": {
+      "name": "MQTT Connector",
+      "github": "FlyingDiver/Indigo-MQTT"
+    },
+    "com.flyingdiver.indigoplugin.mqtt-broker": {
+      "name": "MQTT Broker",
+      "github": "FlyingDiver/Indigo-MQTT-Broker"
+    },
+    "com.flyingdiver.indigoplugin.occupatum": {
+      "name": "Occupatum",
+      "github": "FlyingDiver/Indigo-Occupatum"
+    },
+    "com.flyingdiver.indigoplugin.pushsafer": {
+      "name": "Pushsafer",
+      "github": "IndigoDomotics/indigo-pushsafer"
+    },
+    "com.flyingdiver.indigoplugin.ratgdo": {
+      "name": "ratgdo GDO Controller",
+      "github": "FlyingDiver/Indigo-ratgdo"
+    },
+    "com.flyingdiver.indigoplugin.schlageencode": {
+      "name": "Schlage Encode",
+      "github": "FlyingDiver/Indigo-Schlage"
+    },
+    "com.flyingdiver.indigoplugin.shims": {
+      "name": "MQTT Shims",
+      "github": "FlyingDiver/Indigo-Shims"
+    },
+    "com.flyingdiver.indigoplugin.slack": {
+      "name": "Slack 2",
+      "github": "FlyingDiver/Indigo-Slack2"
+    },
+    "com.flyingdiver.indigoplugin.smtpd": {
+      "name": "SMTPd",
+      "github": "FlyingDiver/Indigo-SMTPd"
+    },
+    "com.flyingdiver.indigoplugin.tankutility": {
+      "name": "TankUtility",
+      "github": "FlyingDiver/Indigo-TankUtility"
+    },
+    "com.flyingdiver.indigoplugin.trane-nexia": {
+      "name": "Trane Home",
+      "github": "FlyingDiver/Indigo-Trane-Nexia"
+    },
+    "com.flyingdiver.indigoplugin.twilio": {
+      "name": "Twilio",
+      "github": "FlyingDiver/Indigo-Twilio"
+    },
+    "com.flyingdiver.indigoplugin.weatherlink-live": {
+      "name": "WeatherLink Live",
+      "github": "FlyingDiver/Indigo-WeatherLinkLive"
+    },
+    "com.fogbert.indigoplugin.GhostXML": {
+      "name": "GhostXML",
+      "github": "IndigoDomotics/GhostXML"
+    },
+    "com.fogbert.indigoplugin.OWServer": {
+      "name": "OWServer",
+      "github": "DaveL17/OWServer"
+    },
+    "com.fogbert.indigoplugin.announcements": {
+      "name": "Announcements",
+      "github": "DaveL17/Announcements"
+    },
+    "com.fogbert.indigoplugin.bikeShare": {
+      "name": "Bike Share",
+      "github": "DaveL17/BikeShare"
+    },
+    "com.fogbert.indigoplugin.fantasticwWeather": {
+      "name": "Fantastic Weather",
+      "github": "DaveL17/Fantastic-Weather"
+    },
+    "com.fogbert.indigoplugin.matplotlib": {
+      "name": "Matplotlib",
+      "github": "DaveL17/matplotlib"
+    },
+    "com.fogbert.indigoplugin.multitool": {
+      "name": "Multitool",
+      "github": "DaveL17/Multitool"
+    },
+    "com.frightideas.indigoplugin.dscAlarm": {
+      "name": "DSC Alarm",
+      "github": "IndigoDomotics/DSC-Alarm"
+    },
+    "com.github.wonderslug.hassbridge": {
+      "name": "HassBridge",
+      "github": "IndigoDomotics/hassbridge"
+    },
+    "com.heddings.indigo.prowl": {
+      "name": "Prowl",
+      "github": "jheddings/indigo-prowl"
+    },
+    "com.howartp.clockdisplay": {
+      "name": "Clock Display",
+      "github": "howartp84/ClockDisplay"
+    },
+    "com.howartp.lockmanager": {
+      "name": "Z-Wave Lock Manager",
+      "github": "howartp84/ZWaveLockManager"
+    },
+    "com.howartp.neoblinds": {
+      "name": "Neo Blinds",
+      "github": "howartp84/NeoSmartBlinds"
+    },
+    "com.howartp.scenecontrol": {
+      "name": "Z-Wave Scene Controller",
+      "github": "howartp84/ZWaveSceneController"
+    },
+    "com.howartp.sense": {
+      "name": "Sense",
+      "github": "howartp84/Sense"
+    },
+    "com.howartp.teslacontrol": {
+      "name": "Tesla EV Control",
+      "github": "howartp84/TeslaControl"
+    },
+    "com.howartp.variabledevice": {
+      "name": "Variable Devices",
+      "github": "howartp84/VariableDevice"
+    },
+    "com.howartp.verisurev2": {
+      "name": "Verisure v2",
+      "github": "howartp84/verisure"
+    },
+    "com.howartp.windowcontrol": {
+      "name": "Z-Wave Window Controller",
+      "github": "howartp84/ZWaveWindowController"
+    },
+    "com.howartp.zwavesensorlogger": {
+      "name": "Z-Wave Sensor Logger",
+      "github": "howartp84/ZWaveSensorLogger"
+    },
+    "com.howartp.zwavewatcher": {
+      "name": "Z-Wave Watcher",
+      "github": "howartp84/ZWaveWatcher"
+    },
+    "com.indigodomo.indigoplugin.autologsqueezeboxcontroller": {
+      "name": "Squeezebox",
+      "github": "autolog/Squeezebox_Controller"
+    },
+    "com.indigodomo.opensource.rachio": {
+      "name": "Rachio Sprinklers",
+      "github": "IndigoDomotics/rachio-indigo"
+    },
+    "com.jeremyswancoat.indigoplugin.nuvograndconcerto": {
+      "name": "NuVo Grand Concerto",
+      "github": "Monstergerm/Indigo-NuvoGrandConcerto"
+    },
+    "com.jeremyswancoat.indigoplugin.pentairpool": {
+      "name": "Pentair Pool",
+      "github": "FlyingDiver/Indigo-Pentair"
+    },
+    "com.jimandnoreen.indigoplugin.lutron-radiora2": {
+      "name": "Lutron RRA2/Cas\u00e9ta",
+      "github": "FlyingDiver/Indigo-radiora2"
+    },
+    "com.karlwachs.INDIGOplotD": {
+      "name": "INDIGOplotD",
+      "github": "kw123/indigoplotd"
+    },
+    "com.karlwachs.VoiceReceiver": {
+      "name": "VoiceReceiver",
+      "github": "kw123/VoiceReceiver"
+    },
+    "com.karlwachs.arduino": {
+      "name": "arduino",
+      "github": "kw123/arduino"
+    },
+    "com.karlwachs.fingscan": {
+      "name": "fingscan",
+      "github": "kw123/fingscan"
+    },
+    "com.karlwachs.homematic": {
+      "name": "homematic",
+      "github": "kw123/homematic"
+    },
+    "com.karlwachs.minMax": {
+      "name": "minMax",
+      "github": "kw123/minMax"
+    },
+    "com.karlwachs.networkscanner": {
+      "name": "Network Scanner",
+      "store_url": "https://www.indigodomo.com/pluginstore/326/",
+      "store_download": "https://downloads.indigodomo.com/pluginstore/com.karlwachs/com.karlwachs.networkscanner/2025.0.2/NetworkScanner.indigoPlugin.zip"
+    },
+    "com.karlwachs.piBeacon": {
+      "name": "piBeacon",
+      "github": "kw123/pibeacon"
+    },
+    "com.karlwachs.secondsSinceLastChange": {
+      "name": "secondsSinceLastChange",
+      "github": "kw123/secondssincelastchnage"
+    },
+    "com.karlwachs.shelly": {
+      "name": "shelly",
+      "github": "kw123/SHELLY"
+    },
+    "com.karlwachs.shutdownAction": {
+      "name": "shutdownAction",
+      "github": "kw123/shutdown-action"
+    },
+    "com.karlwachs.startupAction": {
+      "name": "startupAction",
+      "github": "kw123/startupAction"
+    },
+    "com.karlwachs.uniFiAP": {
+      "name": "uniFiAP",
+      "github": "kw123/unifi"
+    },
+    "com.karlwachs.utilities": {
+      "name": "utilities",
+      "github": "kw123/indigoUtilities"
+    },
+    "com.lionsheeptechnology.ShellyMQTT": {
+      "name": "ShellyMQTT",
+      "github": "AaronLionsheep/ShellyMQTT"
+    },
+    "com.lionsheeptechnology.ShellyNGMQTT": {
+      "name": "ShellyNGMQTT",
+      "github": "AaronLionsheep/ShellyNGMQTT"
+    },
+    "com.lionsheeptechnology.SmartRent": {
+      "name": "SmartRent",
+      "github": "AaronLionsheep/SmartRent"
+    },
+    "com.marcus.indigoplugin.yamaharxaus": {
+      "name": "Yamaha RX Receiver AUS",
+      "store_url": "https://www.indigodomo.com/pluginstore/287/",
+      "store_download": "https://downloads.indigodomo.com/pluginstore/com.marcus/com.marcus.indigoplugin.yamaharxaus/2022.2.1/yamaharx_AUS.indigoPlugin.zip"
+    },
+    "com.mkuchnic.indigoplugin.schluter": {
+      "name": "Schluter Thermostat",
+      "github": "MKuchnic/Indigo-Schluter-1"
+    },
+    "com.morris.confirmed-lock": {
+      "name": "Confirmed Lock",
+      "github": "kmarkley/Indigo-Confirmed-Lock"
+    },
+    "com.morris.default-dimmer-level": {
+      "name": "Default Dimmer Level",
+      "github": "kmarkley/Indigo-Default-Dimmer"
+    },
+    "com.morris.fan-group": {
+      "name": "Fan Group",
+      "github": "kmarkley/Indigo-Fan-Group"
+    },
+    "com.morris.google-calendar": {
+      "name": "Google Calendar",
+      "github": "kmarkley/Indigo-Google-Calendar"
+    },
+    "com.morris.group-change-listener": {
+      "name": "Group Change Listener",
+      "github": "kmarkley/Indigo-Group-Change-Listener"
+    },
+    "com.morris.itunes-local-control": {
+      "name": "iTunes Local Control",
+      "github": "kmarkley/Indigo-iTunes-Local-Control"
+    },
+    "com.morris.lock-group": {
+      "name": "Lock Group",
+      "github": "kmarkley/Indigo-Lock-Group"
+    },
+    "com.morris.mac-apps": {
+      "name": "Mac Apps",
+      "github": "kmarkley/Indigo-Mac-Apps"
+    },
+    "com.morris.neato-botvac": {
+      "name": "Neato Botvac",
+      "github": "kmarkley/Indigo-Neato-Botvac"
+    },
+    "com.morris.online-sensor": {
+      "name": "Online Sensor",
+      "github": "kmarkley/Indigo-Online-Sensor"
+    },
+    "com.morris.over-auto": {
+      "name": "Over Auto",
+      "github": "kmarkley/Indigo-Over-Auto"
+    },
+    "com.morris.realistic-random": {
+      "name": "Realistic Random",
+      "github": "kmarkley/Indigo-Realistic-Random"
+    },
+    "com.morris.sensor-stats": {
+      "name": "Sensor Stats",
+      "github": "kmarkley/Indigo-Sensor-Stats"
+    },
+    "com.morris.state-tree-actions": {
+      "name": "State Tree Actions",
+      "github": "kmarkley/Indigo-State-Tree-Actions"
+    },
+    "com.morris.timed-devices": {
+      "name": "Timed Devices",
+      "github": "kmarkley/Indigo-Timed-Devices"
+    },
+    "com.morris.unistat": {
+      "name": "Unistat",
+      "github": "kmarkley/Indigo-Unistat"
+    },
+    "com.nathansheldon.indigoplugin.HueLights": {
+      "name": "Hue Lights",
+      "github": "kw123/Hue-Lights-Indigo-plugin"
+    },
+    "com.nathansheldon.indigoplugin.PioneerReceiver": {
+      "name": "Pioneer Receiver",
+      "github": "IndigoDomotics/Pioneer-Receiver-Indigo-Plugin"
+    },
+    "com.nathansheldon.indigoplugin.sleepybed-iq": {
+      "name": "SleepyBed IQ",
+      "github": "IndigoDomotics/SleepyBed-IQ-Indigo-Plugin"
+    },
+    "com.nathanw.IndigoPlugin.ESPHomeClimate": {
+      "name": "ESPHome Climate",
+      "github": "nathanjw/ESPHomeClimate-indigo-plugin"
+    },
+    "com.pennypacker.indigoplugin.weatherflow": {
+      "name": "WeatherFlow Smart Weather",
+      "github": "bpennypacker/WeatherFlow-Indigo-Plugin"
+    },
+    "com.perceptiveautomation.indigoplugin.directvdvrcontrol": {
+      "name": "DIRECTV DVR Control",
+      "github": "IndigoDomotics/directv-dvr-control"
+    },
+    "com.perceptiveautomation.indigoplugin.user-scripts": {
+      "name": "User Scripts",
+      "github": "IndigoDomotics/indigo-user-scripts"
+    },
+    "com.pluginfactory.indigoplugin.rainmachine2": {
+      "name": "RainMachine2",
+      "github": "geoffsharris/RainMachine2"
+    },
+    "com.racarter.indigoplugin.blink": {
+      "name": "Blink",
+      "store_url": "https://www.indigodomo.com/pluginstore/273/",
+      "store_download": "https://downloads.indigodomo.com/pluginstore/com.racarter/com.racarter.indigoplugin.blink/2025.1.1/HeatmiserNeo.IndigoPlugin.zip"
+    },
+    "com.racarter.indigoplugin.heatmiser-neo": {
+      "name": "Heatmiser Neo",
+      "store_url": "https://www.indigodomo.com/pluginstore/176/",
+      "store_download": "https://downloads.indigodomo.com/pluginstore/com.racarter/com.racarter.indigoplugin.heatmiser-neo/2025.1.1/HeatmiserNeo.IndigoPlugin.zip"
+    },
+    "com.racarter.indigoplugin.jlr": {
+      "name": "JLR",
+      "store_url": "https://www.indigodomo.com/pluginstore/285/",
+      "store_download": "https://downloads.indigodomo.com/pluginstore/com.racarter/com.racarter.indigoplugin.jlr/2024.0.0/JLR.IndigoPlugin.zip"
+    },
+    "com.racarter.indigoplugin.netatmo-welcome": {
+      "name": "Netatmo Multi",
+      "store_url": "https://www.indigodomo.com/pluginstore/177/",
+      "store_download": "https://downloads.indigodomo.com/pluginstore/com.racarter/com.racarter.indigoplugin.netatmo-welcome/2025.0.3/NetatmoWelcome.IndigoPlugin.zip"
+    },
+    "com.racarter.indigoplugin.ohme": {
+      "name": "Ohme",
+      "store_url": "https://www.indigodomo.com/pluginstore/307/",
+      "store_download": "https://downloads.indigodomo.com/pluginstore/com.racarter/com.racarter.indigoplugin.ohme/2025.0.3/Ohme.IndigoPlugin.zip"
+    },
+    "com.racarter.indigoplugin.sunsynk": {
+      "name": "Sunsynk",
+      "store_url": "https://www.indigodomo.com/pluginstore/276/",
+      "store_download": "https://downloads.indigodomo.com/pluginstore/com.racarter/com.racarter.indigoplugin.sunsynk/2023.0.0/Sunsynk.IndigoPlugin.zip"
+    },
+    "com.racarter.indigoplugin.tapo": {
+      "name": "Tapo",
+      "store_url": "https://www.indigodomo.com/pluginstore/274/",
+      "store_download": "https://downloads.indigodomo.com/pluginstore/com.racarter/com.racarter.indigoplugin.tapo/2023.0.0/Tapo.IndigoPlugin.zip"
+    },
+    "com.racarter.indigoplugin.texecom": {
+      "name": "Texecom",
+      "store_url": "https://www.indigodomo.com/pluginstore/175/",
+      "store_download": "https://downloads.indigodomo.com/pluginstore/com.racarter/com.racarter.indigoplugin.texecom/2022.0.2/Texecom.indigoPlugin.zip"
+    },
+    "com.racarter.indigoplugin.tuya": {
+      "name": "Tuya",
+      "store_url": "https://www.indigodomo.com/pluginstore/279/",
+      "store_download": "https://downloads.indigodomo.com/pluginstore/com.racarter/com.racarter.indigoplugin.tuya/2025.2.1/Tuya.IndigoPlugin.zip"
+    },
+    "com.racarter.indigoplugin.watchdog": {
+      "name": "Watchdog",
+      "store_url": "https://www.indigodomo.com/pluginstore/174/",
+      "store_download": "https://downloads.indigodomo.com/pluginstore/com.racarter/com.racarter.indigoplugin.watchdog/2022.0.0/Watchdog.IndigoPlugin.zip"
+    },
+    "com.ramias.indigo.plugins.pihole": {
+      "name": "Pi Hole DNS Controller",
+      "github": "Ramias1/indigo-pi-hole"
+    },
+    "com.ryanbuckner.indigoplugin.life360": {
+      "name": "Life360",
+      "github": "ryanbuckner/life360-plugin"
+    },
+    "com.schollnick.indigoplugin.BatteryMonitor": {
+      "name": "UPS and Battery Monitor",
+      "github": "FlyingDiver/Indigo-UPS-Battery-Plugin"
+    },
+    "com.sherwinsound.anthemrs232": {
+      "name": "Anthem RS232",
+      "github": "Koreysherwin/indigo-anthem-rs232"
+    },
+    "com.sherwinsound.spotifycontrol": {
+      "name": "Spotify Control",
+      "github": "Koreysherwin/indigo-spotify-control"
+    },
+    "com.sherwinsound.viewsonicprojector": {
+      "name": "ViewSonic Projector",
+      "github": "Koreysherwin/indigo-ViewSonicProjector"
+    },
+    "com.simons-plugins.UKTrains": {
+      "name": "UK Trains",
+      "github": "simons-plugins/indigo-UKTrains"
+    },
+    "com.simons-plugins.domio": {
+      "name": "Domio",
+      "github": "simons-plugins/indigo-domio-plugin"
+    },
+    "com.simons-plugins.logs-over-reflector": {
+      "name": "LogsOverReflector",
+      "github": "simons-plugins/logs-over-reflector"
+    },
+    "com.simons-plugins.netro": {
+      "name": "Netro Sprinklers",
+      "github": "simons-plugins/netro-indigo"
+    },
+    "com.simons-plugins.sofabaton": {
+      "name": "Sofabaton",
+      "github": "simons-plugins/indigo-sofabaton"
+    },
+    "com.smurfless.indigoplugin.json1": {
+      "name": "JSON Broadcast Plugin",
+      "github": "smurfless1/indigo-json-broadcaster"
+    },
+    "com.ssi.indigoplugin.Sonos": {
+      "name": "Sonos",
+      "github": "IndigoDomotics/Sonos"
+    },
+    "com.vtmikel.augusthome": {
+      "name": "August Home",
+      "github": "mlamoure/Indigo-August-Home"
+    },
+    "com.vtmikel.autofan": {
+      "name": "Auto Fan",
+      "github": "mlamoure/indigo-auto-fan-plugin"
+    },
+    "com.vtmikel.autolights": {
+      "name": "Auto Lights",
+      "github": "mlamoure/indigo-auto-lights"
+    },
+    "com.vtmikel.grafana": {
+      "name": "Grafana Home Dashboard",
+      "github": "mlamoure/indigo-grafana-dashboard"
+    },
+    "com.vtmikel.mcp_server": {
+      "name": "MCP Server",
+      "github": "mlamoure/indigo-mcp-server"
+    },
+    "com.vtmikel.securityspyimage": {
+      "name": "Image downloader and SecuritySpy helper",
+      "github": "mlamoure/indigo-securityspy-image-downloader"
+    },
+    "com.weathersnoop.indigoplugin": {
+      "name": "WeatherSnoop",
+      "github": "fluentweather/weathersnoop-indigoplugin"
+    },
+    "com.webdeck.indigoplugin.bafcontrol": {
+      "name": "BAF/Haiku",
+      "github": "webdeck/Indigo-BAF-Control"
+    },
+    "com.whmoorejr.my-people": {
+      "name": "My People",
+      "github": "whmoorejr/My-People"
+    },
+    "com.woodsmachine.indigoplugins.LightScenes": {
+      "name": "Light Scenes",
+      "github": "rbdubz3/light-scenes-indigo"
+    },
+    "com.woodsmachine.indigoplugins.SmartSetpoints": {
+      "name": "Smart Setpoints",
+      "github": "rbdubz3/smart-setpoints-indigo"
+    },
+    "com.woodsmachine.indigoplugins.SylvaniaLightify": {
+      "name": "Sylvania Lightify",
+      "github": "rbdubz3/sylvania-lightify-indigo"
+    },
+    "io.thechad.indigoplugin.pushover": {
+      "name": "Pushover",
+      "github": "IndigoDomotics/indigo-pushover"
+    },
+    "io.thechad.indigoplugin.yamaharx": {
+      "name": "Yamaha RX Receiver",
+      "github": "IndigoDomotics/indigo-yamaharx"
+    },
+    "net.dowles.doorbird": {
+      "name": "DoorBird",
+      "github": "kwijibo007/DoorBird"
+    },
+    "net.dowles.monoprice6zoneamp": {
+      "name": "Monoprice 6 Zone Amp",
+      "github": "kwijibo007/Monoprice-6-Zone-Amp"
+    },
+    "net.papamac.indigoplugin.virtualgaragedoor": {
+      "name": "Virtual Garage Door",
+      "github": "papamac/VirtualGarageDoor"
+    },
+    "net.zengers.weerlive": {
+      "name": "WeerLive",
+      "github": "idurz/indigo-Weerlive"
+    },
+    "nl.rjdekok.indigoplugin.RFXCOM": {
+      "name": "RFXCOM",
+      "github": "IndigoDomotics/rfxcom-plugin"
+    },
+    "no.homeassistant.plugin": {
+      "name": "Home Assistant Agent",
+      "github": "FlyingDiver/Indigo-HA-Agent"
+    },
+    "org.cynic.indigo.behaviors": {
+      "name": "Cynical Behaviors",
+      "store_url": "https://www.indigodomo.com/pluginstore/112/",
+      "store_download": "https://downloads.indigodomo.com/pluginstore/org.cynic/org.cynic.indigo.behaviors/3.2.0/behaviors-3.2.0.zip"
+    },
+    "org.cynic.indigo.carrier.sam": {
+      "name": "Cynical Infinity",
+      "store_url": "https://www.indigodomo.com/pluginstore/301/",
+      "store_download": "https://downloads.indigodomo.com/pluginstore/org.cynic/org.cynic.indigo.carrier.sam/3.2.0/sam-3.2.0.zip"
+    },
+    "org.cynic.indigo.denon-av": {
+      "name": "Cynical Denon",
+      "store_url": "https://www.indigodomo.com/pluginstore/115/",
+      "store_download": "https://downloads.indigodomo.com/pluginstore/org.cynic/org.cynic.indigo.denon-av/3.2.0/denon-av-3.2.0.zip"
+    },
+    "org.cynic.indigo.gcnet": {
+      "name": "Cynical Cach\u00e9",
+      "store_url": "https://www.indigodomo.com/pluginstore/113/",
+      "store_download": "https://downloads.indigodomo.com/pluginstore/org.cynic/org.cynic.indigo.gcnet/3.2.2/gcnet-3.2.2.zip"
+    },
+    "org.cynic.indigo.honey": {
+      "name": "Cynical Honey",
+      "store_url": "https://www.indigodomo.com/pluginstore/116/",
+      "store_download": "https://downloads.indigodomo.com/pluginstore/org.cynic/org.cynic.indigo.honey/3.2.0/honey-3.2.0.zip"
+    },
+    "org.cynic.indigo.lutron": {
+      "name": "Cynical Lutron",
+      "store_url": "https://www.indigodomo.com/pluginstore/117/",
+      "store_download": "https://downloads.indigodomo.com/pluginstore/org.cynic/org.cynic.indigo.lutron/3.2.0/lutron-3.2.0.zip"
+    },
+    "org.cynic.indigo.network": {
+      "name": "Cynical Network",
+      "store_url": "https://www.indigodomo.com/pluginstore/118/",
+      "store_download": "https://downloads.indigodomo.com/pluginstore/org.cynic/org.cynic.indigo.network/3.2.0/network-3.2.0.zip"
+    },
+    "org.cynic.indigo.securityspy": {
+      "name": "Cynical SecuritySpy",
+      "store_url": "https://www.indigodomo.com/pluginstore/119/",
+      "store_download": "https://downloads.indigodomo.com/pluginstore/org.cynic/org.cynic.indigo.securityspy/3.2.0/securityspy-3.2.0.zip"
+    },
+    "org.cynic.indigo.weather": {
+      "name": "Cynical Weather",
+      "store_url": "https://www.indigodomo.com/pluginstore/120/",
+      "store_download": "https://downloads.indigodomo.com/pluginstore/org.cynic/org.cynic.indigo.weather/3.5.5/weather-3.5.5.zip"
+    },
+    "pro.sleepers.indigoplugin.8channel-relay": {
+      "name": "8 Channel Network Relay",
+      "github": "IndigoDomotics/indigo-8channel-relay"
+    },
+    "se.cobmedia.indigoplugin.virtualenergymeter": {
+      "name": "Virtual Energy Meter",
+      "github": "IndigoDomotics/Indigo-VirtualEnergyMeter"
+    },
+    "se.furtenbach.indigo.plugin.beacon": {
+      "name": "GeoFence",
+      "github": "FlyingDiver/Indigo-GeoFence"
+    },
+    "uk.co.greensky.flux": {
+      "name": "Flux LED",
+      "github": "IndigoDomotics/IndigoFluxLED"
+    }
+  }
+}

--- a/skills/update-plugins/SKILL.md
+++ b/skills/update-plugins/SKILL.md
@@ -25,37 +25,15 @@ Call `mcp__indigo__list_plugins` (default `include_disabled=false`). For each re
 
 ### Phase 2 — RESOLVE UPGRADE SOURCE
 
-For each plugin, see `references/discovery.md`. Short version:
+Three sources checked in priority order. Full details in `references/discovery.md`. Short version:
 
-1. **Try GitHub** — read `<path>/Contents/Info.plist` for `GithubInfo.GithubUser` + `GithubInfo.GithubRepo`. If present → `gh api /repos/<user>/<repo>/releases/latest` → capture `tag_name`, `html_url`, and any asset ending in `.indigoPlugin.zip`.
-2. **Try store** — no GithubInfo → look up the bundle ID in the store cache (Phase 3).
-3. **Unresolved** — neither source resolves → record and continue.
+1. **Local `GithubInfo`** — read `<path>/Contents/Info.plist` for `GithubInfo.GithubUser` + `GithubInfo.GithubRepo`. If present → `gh api /repos/<user>/<repo>/releases/latest`.
+2. **Bundled registry** (`$CLAUDE_PLUGIN_ROOT/data/plugin-source-registry.json`) — a static `bundle_id → upstream` map that ships with this marketplace plugin. If the bundle ID is in the registry, use its `github` slug (preferred) or fetch its `store_url` (fallback for store-only plugins). **No runtime scraping for plugins in the registry** — it's a file read.
+3. **Store scraping fallback** — for plugins in neither Info.plist nor the registry. Rare. See `references/store-scraping.md`. Suggest the user open a PR adding an entry to the registry when this path triggers.
 
-Parallelise. See `references/discovery.md` for the cap and concurrency notes.
+Parallelise. See `references/discovery.md` for concurrency notes.
 
-### Phase 3 — MAINTAIN STORE CACHE
-
-Cache at `$HOME/.claude/indigo-plugin-store-cache.json`. Schema:
-
-```json
-{
-  "fetched_at": "2026-04-15T12:00:00Z",
-  "listing_etag": "...",
-  "plugins": {
-    "pro.sleepers.indigoplugin.8channel-relay": {
-      "name": "8 Channel Network Relay",
-      "latest_version": "2.0.1",
-      "detail_url": "https://www.indigodomo.com/pluginstore/196/",
-      "download_url": "https://github.com/IndigoDomotics/indigo-8channel-relay/releases/download/v2.0.1/8chRelay.indigoPlugin.zip",
-      "github_url": "https://github.com/IndigoDomotics/indigo-8channel-relay"
-    }
-  }
-}
-```
-
-Refresh when: file missing, older than 24h, or the user asks. Full refresh procedure, parse rules, and the self-test that guards against HTML drift: see `references/store-scraping.md`.
-
-### Phase 4 — DIFF
+### Phase 3 — DIFF
 
 For each plugin with a resolved upstream, compare installed version to latest. Strip a leading `v`. Prefer `python3 -c 'from packaging.version import parse as p; ...'` if Python is available in the runtime; otherwise split on `.` and compare numeric segments, falling back to string compare if a segment isn't an integer. `2026.4.1`, `1.0.3`, `v1.0-beta` should all work.
 
@@ -78,7 +56,7 @@ Produce a grouped report:
 |--------|-----------|-------|
 ```
 
-### Phase 5 — CONFIRM
+### Phase 4 — CONFIRM
 
 Print the report. Wait for the user. Accepted replies:
 
@@ -89,11 +67,11 @@ Print the report. Wait for the user. Accepted replies:
 
 Anything ambiguous → ask again.
 
-### Phase 6 — APPLY
+### Phase 5 — APPLY
 
 Follow `references/install-workflow.md` per plugin, one at a time. That file is the authoritative sequence; do not reinvent it here.
 
-### Phase 7 — SUMMARY
+### Phase 6 — SUMMARY
 
 Print three sections: **Upgraded** (name, old → new version), **Failed** (name, reason, one-line manual recovery hint), **Unresolved** (name, why no source was found).
 

--- a/skills/update-plugins/references/discovery.md
+++ b/skills/update-plugins/references/discovery.md
@@ -1,10 +1,12 @@
 # Upgrade Source Discovery
 
-How to find the upstream source for an installed Indigo plugin. Sources are checked in priority order; fall through on miss.
+How to find the upstream source for an installed Indigo plugin. Three sources, checked in priority order; fall through on miss.
 
 ## Source 1: `Info.plist` `GithubInfo` (preferred)
 
-Indigo plugins that ship via GitHub embed a `GithubInfo` dict in `Contents/Info.plist`. Example:
+Plugins that ship via GitHub often embed a `GithubInfo` dict in `Contents/Info.plist`. When present, it gives us the repo coordinates with zero guessing and works for every install of that plugin without needing any shared data.
+
+Example:
 
 ```xml
 <key>GithubInfo</key>
@@ -38,37 +40,78 @@ Capture:
 - `html_url` — release page, used as release notes link
 - `assets[*]` — find the entry whose `name` ends in `.indigoPlugin.zip`; record its `browser_download_url`. If no such asset exists, mark the plugin as unresolved (upstream exists but doesn't publish a downloadable bundle)
 
-`gh api` returns 404 if the repo has no releases published yet, or if the repo is private and the user's token doesn't have access. Both cases → mark the plugin as unresolved with a short reason string so the user knows why.
+`gh api` returns 404 if the repo has no releases yet, or if it's private and the user's token lacks access. Both cases → mark the plugin as unresolved with a short reason string so the user knows why.
 
-## Source 2: Indigo plugin store (fallback)
+## Source 2: Bundled plugin source registry
 
-For plugins with no `GithubInfo`, look up the bundle ID in the store cache. The cache is a pre-scraped `bundle_id → metadata` map built by Phase 3. See `store-scraping.md` for the scrape rules and the hard-earned caveats about what the store HTML actually exposes.
+`data/plugin-source-registry.json` at the root of this marketplace plugin is a pre-populated map of `bundle_id → upstream`. Ships as static data so there is **zero runtime scraping** for plugins in the registry — it's a file read, not a network request. Fresh registry updates arrive via `/plugin marketplace update`, the same mechanism users already use to get new skill code.
 
-**If the bundle ID is in the cache:**
-- `latest_version` → compare against installed
-- `download_url` → prefer this (often points at a GitHub release asset even for store-sourced plugins — you're effectively using GitHub releases with the store as a directory)
-- `detail_url` → release notes link
+### Registry schema
 
-**If the bundle ID is NOT in the cache:**
-- Plugin isn't listed on the store → mark unresolved, continue
+```json
+{
+  "updated_at": "2026-04-15",
+  "note": "...",
+  "source": "...",
+  "plugins": {
+    "<bundle_id>": {
+      "name": "Human-readable name",
+      "github": "user/repo"
+    },
+    "<other_bundle_id>": {
+      "name": "Human-readable name",
+      "store_url": "https://www.indigodomo.com/pluginstore/N/",
+      "store_download": "https://downloads.indigodomo.com/pluginstore/.../plugin.indigoPlugin.zip"
+    }
+  }
+}
+```
 
-## Source 3: Unresolved
+Entries come in two shapes:
 
-Plugins with no upstream source. Informational only, not an error. Common reasons:
+**GitHub-backed** — has a `github` field (`user/repo` slug). Resolution is identical to Source 1: query `gh api /repos/<github>/releases/latest` and use the tag + asset URL. This is the overwhelming majority of entries (~90% after the initial seed).
+
+**Store-only** — has `store_url` and optionally `store_download`. The plugin is published via Indigo's store with no GitHub mirror, so we still need a lightweight runtime fetch to get the latest version. Fetch the `store_url` detail page, parse it per `store-scraping.md`, and extract the latest version and download URL. This is one HTTP GET per store-only plugin per run (no listing enumeration, no cache-build sweep).
+
+### Loading the registry
+
+```bash
+REGISTRY="$CLAUDE_PLUGIN_ROOT/data/plugin-source-registry.json"
+```
+
+`$CLAUDE_PLUGIN_ROOT` is set by Claude Code to the root of this marketplace plugin. Read the JSON, look up the installed bundle ID under `.plugins`:
+
+```bash
+jq -e ".plugins[\"$BUNDLE_ID\"]" "$REGISTRY"
+```
+
+Non-zero exit → not in the registry → fall through to Source 3.
+
+### Contributing to the registry
+
+Users who discover a plugin not in the registry — or a GitHub URL the registry doesn't know about — are expected to open a PR against `simons-plugins/indigo-claude-plugin` adding or updating an entry. The registry is a flat JSON file, easy to edit, and the next marketplace update pushes the change to everyone.
+
+Keep entries minimal. No versions, no dates, no dependency info — the whole file is just a routing table from bundle ID to upstream.
+
+## Source 3: Store scraping fallback (rare)
+
+For installed plugins that are in neither the local Info.plist nor the bundled registry. See `store-scraping.md`. This path is now expected to be unusual — the bundled registry covers the common case, so store scraping only kicks in when a user has installed a plugin the registry author hasn't seen yet.
+
+When this path triggers, suggest to the user that they open a PR to add the plugin to the bundled registry so future users don't need to re-scrape.
+
+## Unresolved
+
+Plugins that didn't resolve through any of the three sources. Informational, not an error. Common reasons:
 
 - Sideloaded from a private `.indigoPlugin.zip`
-- Lives on GitHub but doesn't declare `GithubInfo` and isn't on the store
+- Lives on GitHub but neither the Info.plist nor the registry knows the repo
 - Author distributes via their own website
 - Plugin was never fully set up
 
-Manual remediation hint: "check the plugin's documentation or contact the author for update instructions."
+Manual remediation hint: "check the plugin's documentation or contact the author for update instructions, then consider adding an entry to `data/plugin-source-registry.json`."
 
 ## Parallelisation
 
-Phase 2 is per-plugin independent. Run it concurrently with background bash — `gh api` calls and `PlistBuddy` reads are independent. Cap concurrency at ~8 to be polite to GitHub and the user's network. For small plugin counts (<10) serial is fine.
+Phase 2 is per-plugin independent. Run it concurrently with background bash — `gh api` calls, `PlistBuddy` reads, and registry lookups are all independent. Cap concurrency at ~8 to be polite to GitHub and the user's network. For small plugin counts (<10) serial is fine.
 
-Don't persist per-plugin Phase 2 results across runs — GitHub releases change and a stale per-plugin cache produces wrong diffs. The store cache persists; GitHub queries do not.
-
-## Future: shared source-of-truth catalog
-
-A shared `bundle_id → {user, repo}` mapping hosted in a public repo (e.g. as `plugin-source-registry.json` in `indigo-device-catalog`) could replace most of Source 2. The current store-scraping fallback is necessary only because some plugins on the Indigo store don't declare `GithubInfo` locally. A user-maintained catalog would let one person's scrape work benefit everyone, and would reduce store-page fetches to the long tail. Not implemented in v1.5.0; planned as a follow-up. When it lands, the resolution order becomes: local `GithubInfo` → shared catalog → store scrape → unresolved.
+Don't persist per-plugin Phase 2 results across runs — GitHub releases change and a stale per-plugin cache produces wrong diffs. The registry is the only persistent data; live version checks against GitHub or store are always fresh.

--- a/skills/update-plugins/references/store-scraping.md
+++ b/skills/update-plugins/references/store-scraping.md
@@ -1,90 +1,83 @@
-# Indigo Plugin Store Scraping
+# Indigo Plugin Store Scraping (rare path)
 
-Last-resort fallback for plugins that don't declare `GithubInfo` in their Info.plist. Prefer Source 1 (local GithubInfo) whenever possible — see `discovery.md`.
+Runtime scraping of the Indigo plugin store. Called in two situations:
 
-**Everything in this file is a hypothesis until verified against real store HTML.** The parse rules below are sketched from reading one sample detail page. They will need empirical refinement on first implementation, and the self-test at the end is designed to fail loudly if the HTML drifts away from what's documented here.
+1. **Store-only registry entries** — a plugin is in `data/plugin-source-registry.json` with a `store_url` (not a `github` slug). The registry tells us the exact detail page URL; we fetch it and parse to get the latest version and download URL. One HTTP GET per store-only plugin per run.
+2. **Unknown plugin fallback** — a plugin is installed locally but not in Info.plist AND not in the bundled registry. We don't know its detail URL, so we need to enumerate and match. This path should be rare once the registry is seeded; treat it as a recovery mode and suggest the user open a PR adding a registry entry when it triggers.
 
-## What the store does and doesn't guarantee
+The second path is expensive and lossy. The first path is cheap and deterministic. **Prefer the first whenever possible.**
 
-The Indigo plugin store has no documented JSON/RSS/API feed. Detail pages appear to be server-rendered static HTML readable by `WebFetch` without JavaScript.
+## What the store exposes
 
-The fields below are what we *hope* to extract. The one with the highest rot/availability risk is the **bundle identifier** — it is the match key for the whole fallback path, and it is not guaranteed to be rendered in human-readable form on every detail page. If a given plugin's detail page doesn't expose the bundle ID, we cannot match it to an installed plugin and the fallback collapses for that plugin.
+The store has no documented JSON/RSS/API feed. Detail pages are server-rendered static HTML readable by `WebFetch` without JavaScript. Empirically (from the initial seed scrape of ~210 detail pages), every page reliably exposes:
 
-## Fields to extract (hypothesised)
+- Plugin name (heading)
+- Latest version string (as "Latest Version: vX.Y.Z")
+- Download URL (anchor pointing at either a github.com release asset or a `downloads.indigodomo.com/...` URL)
 
-| Field | Purpose | Availability |
-|-------|---------|--------------|
-| Bundle identifier | Match key against installed plugins | **Uncertain** — not visible on every store page; verify empirically |
-| Latest version | Version comparison | Likely visible as "Latest Version: vX.Y.Z" |
-| Download URL | Target for `curl` in apply phase | Anchor pointing at a `.zip` (often `github.com/.../releases/download/...`) |
-| GitHub URL | Release notes fallback | Anchor pointing at `github.com/<user>/<repo>` |
-| Plugin name + author | Display | Page heading + "Author: ..." text |
+The **bundle identifier** is hit-or-miss — some pages expose it in the visible text, others don't. For store-only registry entries this isn't a problem (we already know the bundle ID from the registry), but it's why the unknown-plugin fallback path is unreliable for bulk discovery.
 
-**If the bundle identifier isn't extractable for a plugin, skip it in the cache rather than persist a partial record.** Reporting no-upstream is better than wrong-upstream.
+## Path 1: Store-only registry entry (preferred runtime use)
 
-## Listing discovery
+The registry entry already contains:
+- `store_url` — the detail page URL
+- `store_download` (optional) — a previously-seen download URL, may be stale
 
-The store doesn't publish a sitemap. Two strategies, try A first:
+Fetch the detail page, parse it, extract:
+- `latest_version` — for the version diff
+- `download_url` — the current download URL (use this; don't trust the cached `store_download` field which may be stale)
 
-### Strategy A — Landing page crawl (preferred)
+Single fetch. No enumeration, no cache.
 
-1. Fetch `https://www.indigodomo.com/pluginstore/`
-2. Parse anchors pointing at detail pages (URL pattern: `https://www.indigodomo.com/pluginstore/<N>/` where `<N>` is a small integer)
-3. Follow category/pagination links if present
-4. Deduplicate, fetch each detail page, parse, store in cache
+## Path 2: Unknown plugin fallback (recovery mode)
 
-### Strategy B — Sequential ID enumeration (fallback)
+A plugin is installed, has no `GithubInfo`, and isn't in the registry. We have the bundle ID from MCP but no way to map it to a detail page directly.
 
-If the landing page demonstrably misses plugins: walk integer IDs from 1 upward until you hit a run of ~20 consecutive 404s. Don't run both strategies — it's wasted requests.
+Procedure:
+1. Fetch `https://www.indigodomo.com/pluginstore/` to enumerate all detail page URLs
+2. Fetch each one (parallelise, cap 4-6 concurrent)
+3. Parse each for bundle ID
+4. Match on bundle ID → found the detail page → treat as Path 1 from here
 
-## Parse rules (hypotheses — refine on first run)
+This is slow (~200 fetches). Cache the results for 24h in `$HOME/.claude/indigo-plugin-store-cache.json` as a `bundle_id → detail_url` map so subsequent runs within the cache window don't re-enumerate. When this path succeeds, tell the user: "This plugin isn't in the bundled registry yet. Consider opening a PR at `simons-plugins/indigo-claude-plugin` to add it, so future users don't need the fallback scrape."
 
-Keep all selectors in this one file. When the store HTML drifts, this should be the only file that needs updating.
+If the fallback fails to find a matching bundle ID → mark the plugin unresolved.
 
-Use defensive parsing: one CSS/structural selector and a regex fallback for each field, so a single DOM change doesn't take everything out at once.
+## Parse rules
 
-Starting anchors:
+Defensive parsing: CSS selector OR regex fallback for each field, so a single DOM change doesn't break everything. Keep every selector/regex in this file so HTML drift can be fixed in one place.
+
+Starting anchors (refine empirically as the store HTML changes):
 
 ```text
 Bundle identifier: text matching /Bundle Identifier[:\s]+([a-z0-9._-]+)/i
+                   (not always present — fine for Path 1, critical for Path 2)
 Latest version:    text matching /Latest Version[:\s]+v?([0-9][0-9a-z.+\-]*)/i
 Download URL:      any <a href> ending in `.indigoPlugin.zip` or `.zip`
 GitHub URL:        any <a href> matching `github.com/<user>/<repo>` (no trailing path)
 Name:              <h1> or <title> text, stripped of the site suffix
-Author:            text matching /Author[:\s]+([^\n]+)/i
 ```
 
-If any field extraction returns None for a detail page, log a warning with the URL and skip that plugin.
+If a field extraction returns None for a detail page in Path 1, log a warning and report the plugin as unresolved for this run.
 
 ## Parse self-test
 
-Before writing a freshly-built cache to disk, verify the parser still works against a pinned reference URL with pinned expected values. Use a URL, not just a plugin name — plugin names can be renamed or removed, but the detail URL + expected bundle ID are the actual contract:
+Before trusting any parse result, run the self-test against a pinned reference URL:
 
 - Reference URL: `https://www.indigodomo.com/pluginstore/196/`
 - Expected bundle ID: `pro.sleepers.indigoplugin.8channel-relay`
 - Expected name substring: `8 Channel`
 
-Fetch the URL, run the parser, assert all five required fields extract and that bundle ID + name match. If any assertion fails:
-
-- Do **not** write the cache
-- Report: "Indigo plugin store HTML has drifted — store-sourced upgrade detection is disabled until `references/store-scraping.md` is updated with fresh parse rules"
-- Continue with Source 1 (GithubInfo-backed plugins still work)
-
-This guards against silent rot where the scraper keeps producing empty results after a store redesign.
+If the assertions fail, the store HTML has drifted. Report: "Indigo plugin store HTML has drifted — store-based upgrade detection is temporarily disabled. Update `skills/update-plugins/references/store-scraping.md` with fresh parse rules, or skip affected plugins for this run." Continue with Source 1 (Info.plist GithubInfo) and Source 2 github-backed registry entries — those paths don't depend on store HTML.
 
 ## Politeness
 
-- Cap concurrent detail-page fetches at 4-6
+- Cap concurrent detail-page fetches at 4-6 during Path 2 enumeration
 - Add a small inter-request delay (100-250ms) between batches
 - User-Agent: `indigo-claude-plugin/<version> (update-plugins skill)`
-- Cache aggressively (24h default) so a typical user hits the store at most once per day
+- Aggressively cache (24h) Path 2 results
 
-## Download URL preference
+## Store newer than registry, registry newer than installed
 
-When the store's download anchor already points at a GitHub release asset, use that URL directly — it's tagged, stable, and carries release notes. Only fall back to store-hosted downloads when no GitHub asset URL is linked.
-
-If the store's download URL is relative (e.g. `/pluginstore/download/...`), resolve it against `https://www.indigodomo.com/` before caching.
-
-## Store older than installed
-
-If the store lists an older version than what's installed, the user is running a dev/beta that isn't on the store yet. Report as "installed is newer than store" and do not offer a downgrade.
+- If the store lists a version older than what's installed → the user is running a dev/beta. Report as "installed is newer than store" and don't offer a downgrade.
+- If the bundled registry points at a `store_url` but the store now links to a GitHub release → the plugin author has moved to GitHub. The registry is out of date; suggest a PR updating the entry to use a `github` slug instead.


### PR DESCRIPTION
## Summary

- Adds `data/plugin-source-registry.json` — a static `bundle_id → upstream` map covering 208 plugins from the Indigo plugin store (187 GitHub-backed, 21 store-only). Seeded by a one-off parallel scrape of 210 store detail pages on 2026-04-15.
- The `/indigo:update-plugins` skill's resolution order becomes: local `Info.plist` `GithubInfo` → bundled registry (file read, zero network) → store scraping fallback (rare, only for plugins in neither). Most plugins now resolve without any runtime scraping.
- Store cache is retired. The bundled registry replaces it for the common case, and store-only registry entries are fetched on-demand by exact URL (no enumeration sweep).
- Version bump `1.5.0 → 1.6.0` (new user-visible capability: much broader plugin coverage without per-user scraping).

## Why a registry inside this repo and not `indigo-device-catalog`?

`indigo-device-catalog` is about devices. Shoehorning a plugin registry there conflates two unrelated domains. Keeping the registry co-located with the skill that consumes it means:

- No cross-repo dependency
- No runtime network fetch — `$CLAUDE_PLUGIN_ROOT/data/plugin-source-registry.json` is on disk as soon as the marketplace plugin is installed
- Updates ship via the normal `/plugin marketplace update` cycle users already trust
- Community contributions are plain PRs against `simons-plugins/indigo-claude-plugin`, same as everything else in the repo

## Files

- **New**: `data/plugin-source-registry.json` (208 entries, ~860 lines)
- **Modified**: `skills/update-plugins/SKILL.md`, `commands/update-plugins.md`, `skills/update-plugins/references/discovery.md`, `skills/update-plugins/references/store-scraping.md` — all updated to describe the three-source resolution model and the retired store cache
- **Modified**: `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` — version bump

## Registry shape

```json
{
  "updated_at": "2026-04-15",
  "plugins": {
    "pro.sleepers.indigoplugin.8channel-relay": {
      "name": "8 Channel Network Relay",
      "github": "IndigoDomotics/indigo-8channel-relay"
    },
    "com.karlwachs.networkscanner": {
      "name": "Network Scanner",
      "store_url": "https://www.indigodomo.com/pluginstore/326/",
      "store_download": "https://downloads.indigodomo.com/pluginstore/.../NetworkScanner.indigoPlugin.zip"
    }
  }
}
```

No versions stored — GitHub API is always the source of truth for "latest".

## Test plan

- [ ] `/plugin marketplace update indigo-claude-plugin` loads 1.6.0 cleanly
- [ ] `/indigo:update-plugins` enumerates installed plugins and correctly classifies them by source (GithubInfo / registry-github / registry-store / unresolved)
- [ ] Registry lookup happens before store scraping for a plugin that has no local GithubInfo but is in the registry
- [ ] Store-only registry entries fetch their `store_url` at runtime to get the current version (single fetch, not a full cache rebuild)
- [ ] Fallback store enumeration only triggers for plugins in neither Info.plist nor the registry
- [ ] Spot-check 3-5 registry entries against the real store detail pages to confirm GitHub slugs and store URLs are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin version to 1.6.0
  
* **Documentation**
  * Updated plugin update process documentation with revised resolution workflow and phase structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->