### PR TITLE
feat: v1.7 — live registry overlay, zipball fallback, MCP self-upgrade guard

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "indigo",
       "source": "./",
       "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "repository": "https://github.com/simons-plugins/indigo-claude-plugin",
       "license": "MIT",
       "keywords": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "indigo",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
   "repository": "https://github.com/simons-plugins/indigo-claude-plugin"
 }

--- a/commands/update-plugins.md
+++ b/commands/update-plugins.md
@@ -37,19 +37,35 @@ Call `mcp__indigo__list_plugins` with its default parameters (disabled plugins a
 
 - `id` (bundle identifier — the match key)
 - `name` (display name)
-- `version` (installed version)
 - `path` (bundle path on the Indigo server — used for reading Info.plist and as the deploy destination)
 - `enabled`
+
+**Read the real installed version directly from Info.plist**, not from MCP's `version` field:
+
+```bash
+/usr/libexec/PlistBuddy -c "Print :PluginVersion" "$PATH/Contents/Info.plist"
+```
+
+The `version` field from MCP returns `CFBundleVersion` (rarely updated) rather than `PluginVersion` — useless for diffs.
+
+**Cross-mount note**: if `$PATH` from MCP isn't directly accessible (Indigo runs on a different Mac than this skill), apply a mount prefix. See `references/install-workflow.md` "Deploy path portability" section.
 
 ### Phase 2 — RESOLVE UPGRADE SOURCE
 
 For each installed plugin, determine where to check for updates. See `references/discovery.md` for the full logic. Summary (three sources in priority order):
 
-1. **Local `GithubInfo`** — read `<path>/Contents/Info.plist` via `/usr/libexec/PlistBuddy`. If `GithubInfo.GithubUser` + `GithubInfo.GithubRepo` are present → query `gh api /repos/<user>/<repo>/releases/latest`.
-2. **Bundled registry** — look up the bundle ID in `$CLAUDE_PLUGIN_ROOT/data/plugin-source-registry.json`. Entries have either a `github` slug (→ GitHub releases) or a `store_url` (→ fetch the store detail page for version + download). No runtime scraping for plugins in the registry.
+1. **Local `GithubInfo`** — read `<path>/Contents/Info.plist` via `/usr/libexec/PlistBuddy`. If `GithubInfo.GithubUser` + `GithubInfo.GithubRepo` are present → query `gh api /repos/<user>/<repo>/releases/latest`. **On gh-api 404 or error, fall through to Source 2** — local metadata can be stale.
+2. **Bundled registry** — look up the bundle ID in `$CLAUDE_PLUGIN_ROOT/data/plugin-source-registry.json`. Entries carry any of `github` / `store_url` / `store_download`. Resolver prefers `github` (→ `gh api releases/latest` → `.indigoPlugin.zip` asset → zipball fallback → `store_download` fallback). Store-only entries fetch the `store_url` detail page at runtime. No listing-enumeration sweeps for plugins in the registry.
 3. **Store scraping fallback** — for plugins in neither Info.plist nor the registry. See `references/store-scraping.md`. Rare; suggest a PR adding the plugin to the registry when it triggers.
 
-If none resolve → mark unresolved and continue.
+Before loading the bundled registry, check for a **live overlay** at `$HOME/.claude/indigo-plugin-source-registry-live.json`:
+- If present and younger than 6 hours, use it directly
+- Otherwise, fetch `https://raw.githubusercontent.com/simons-plugins/indigo-claude-plugin/main/data/plugin-source-registry.json`, validate, write atomically, use
+- On fetch failure, fall back to the bundled copy
+
+This lets contributors' PRs take effect immediately without waiting for a marketplace release. `/indigo:update-plugins refresh` forces a cache bust.
+
+If none of the three sources resolve → mark unresolved and continue.
 
 Parallelise across plugins — a 30-plugin serial pass over the network is painfully slow.
 
@@ -76,17 +92,20 @@ Do not interpret ambiguous replies as consent. When in doubt, ask again.
 
 ### Phase 5 — APPLY (per plugin, one at a time)
 
-Follow `references/install-workflow.md` for the exact sequence. Every step — download, unzip-before-copy, verify bundle ID, rsync over the installed `Contents/`, restart via MCP, verify startup — is documented there with the commands to run. Don't reinvent the sequence here.
+Follow `references/install-workflow.md` for the exact sequence. Every step — download (with asset → zipball → store_download fallback chain), unzip with nested-bundle support, verify bundle ID, stop plugin, rsync, start plugin, verify startup — is documented there with the commands to run. Don't reinvent the sequence here.
+
+**Hard limitation**: if the batch includes `com.vtmikel.mcp_server`, treat it specially. Restarting the MCP server kills this skill's own connection. Either skip with a manual-instruction message, or deploy-without-restart and tell the user exactly which `mcp__indigo__restart_plugin(...)` call to run from a fresh session. See the "Hard limitations" section in `install-workflow.md`.
 
 Report pass/fail per plugin. On failure of one plugin, continue to the next — don't halt the whole batch unless the failure indicates something systemic (filesystem unwritable, MCP unreachable, network dead).
 
 ### Phase 6 — SUMMARY
 
-Report three sections:
+Report these sections:
 
 - **Upgraded** — name, old → new version
 - **Failed** — name, error, a one-line manual recovery hint
-- **Unresolved** — name, reason (no GithubInfo, not in store, etc.)
+- **Deferred** — any plugins held for manual handling (MCP Server, user-excluded, etc.), with the exact manual steps
+- **Unresolved** — name, reason (no GithubInfo, not in registry, etc.)
 
 If any plugin failed, suggest a concrete manual next step (check the bundle path, try a manual download, file an issue with the plugin author).
 

--- a/commands/update-plugins.md
+++ b/commands/update-plugins.md
@@ -43,12 +43,13 @@ Call `mcp__indigo__list_plugins` with its default parameters (disabled plugins a
 **Read the real installed version directly from Info.plist**, not from MCP's `version` field:
 
 ```bash
-/usr/libexec/PlistBuddy -c "Print :PluginVersion" "$PATH/Contents/Info.plist"
+PLUGIN_PATH="..."  # `path` from mcp__indigo__list_plugins (mount-prefixed if needed)
+/usr/libexec/PlistBuddy -c "Print :PluginVersion" "$PLUGIN_PATH/Contents/Info.plist"
 ```
 
 The `version` field from MCP returns `CFBundleVersion` (rarely updated) rather than `PluginVersion` — useless for diffs.
 
-**Cross-mount note**: if `$PATH` from MCP isn't directly accessible (Indigo runs on a different Mac than this skill), apply a mount prefix. See `references/install-workflow.md` "Deploy path portability" section.
+**Cross-mount note**: if the MCP-reported path isn't directly accessible (Indigo runs on a different Mac than this skill), apply a mount prefix. See `references/install-workflow.md` "Deploy path portability" section.
 
 ### Phase 2 — RESOLVE UPGRADE SOURCE
 

--- a/data/plugin-source-registry.json
+++ b/data/plugin-source-registry.json
@@ -1,467 +1,698 @@
 {
   "updated_at": "2026-04-15",
-  "note": "Static bundle_id \u2192 upstream map for Indigo plugins. Entries with `github` point at a github.com/user/repo slug (preferred upstream \u2014 use GitHub releases). Entries with `store_url` are Indigo store-hosted; the skill must fetch the store detail page at runtime to get the latest version and download URL.",
+  "schema_version": 2,
+  "note": "Static bundle_id \u2192 upstream map for Indigo plugins. Every entry has `name`. Entries may carry `github` (user/repo slug \u2014 preferred upstream), `store_url` (Indigo plugin store detail page), and/or `store_download` (direct download URL from the store, useful as a fallback when the GitHub release has no .indigoPlugin.zip asset).",
   "source": "Scraped from https://www.indigodomo.com/pluginstore/ detail pages on 2026-04-15. Contribute additions or corrections via PR to simons-plugins/indigo-claude-plugin.",
   "plugins": {
     "com.GlennNZ.indigoplugin.ActronQUE": {
       "name": "Actron QUE AC",
-      "github": "ghawken/ActronQue-IndigoPlugin"
+      "github": "ghawken/ActronQue-IndigoPlugin",
+      "store_url": "https://www.indigodomo.com/pluginstore/234/",
+      "store_download": "https://api.github.com/repos/Ghawken/ActronQue-IndigoPlugin/zipball/0.6.35"
     },
     "com.GlennNZ.indigoplugin.BlueIris": {
       "name": "BlueIris Plugin",
-      "github": "ghawken/IndigoPlugin-BlueIris"
+      "github": "ghawken/IndigoPlugin-BlueIris",
+      "store_url": "https://www.indigodomo.com/pluginstore/149/",
+      "store_download": "https://api.github.com/repos/Ghawken/IndigoPlugin-BlueIris/zipball/1.3.11"
     },
     "com.GlennNZ.indigoplugin.DeepQuestAI": {
       "name": "DeepQuestAI Plugin",
-      "github": "ghawken/DeepQuestAI"
+      "github": "ghawken/DeepQuestAI",
+      "store_url": "https://www.indigodomo.com/pluginstore/247/",
+      "store_download": "https://api.github.com/repos/Ghawken/DeepQuestAI/zipball/0.8.0"
     },
     "com.GlennNZ.indigoplugin.ESPhome4indigo": {
       "name": "ESPHome Indigo Plugin",
-      "github": "ghawken/ESPHome_IndigoPlugin"
+      "github": "ghawken/ESPHome_IndigoPlugin",
+      "store_url": "https://www.indigodomo.com/pluginstore/293/",
+      "store_download": "https://api.github.com/repos/Ghawken/ESPHome_IndigoPlugin/zipball/0.1.25"
     },
     "com.GlennNZ.indigoplugin.EmbyPlugin": {
       "name": "Emby Plugin",
-      "github": "ghawken/EmbyPlugin.indigoPlugin"
+      "github": "ghawken/EmbyPlugin.indigoPlugin",
+      "store_url": "https://www.indigodomo.com/pluginstore/123/",
+      "store_download": "https://github.com/Ghawken/EmbyPlugin.indigoPlugin/releases/download/0.1.5/EmbyPlugin.indigoPlugin.zip"
     },
     "com.GlennNZ.indigoplugin.EnphaseEnvoy": {
       "name": "Enphase Envoy Plugin",
-      "github": "Ghawken/IndigoEnphaseEnvoy"
+      "github": "Ghawken/IndigoEnphaseEnvoy",
+      "store_url": "https://www.indigodomo.com/pluginstore/105/",
+      "store_download": "https://api.github.com/repos/Ghawken/IndigoEnphaseEnvoy/zipball/1.0.01"
     },
     "com.GlennNZ.indigoplugin.FindFriendsMini": {
       "name": "FindFriendsMini",
-      "github": "ghawken/IndigoPlugin-iFindFriendMini"
+      "github": "ghawken/IndigoPlugin-iFindFriendMini",
+      "store_url": "https://www.indigodomo.com/pluginstore/139/",
+      "store_download": "https://api.github.com/repos/Ghawken/IndigoPlugin-iFindFriendMini/zipball/1.7.20"
     },
     "com.GlennNZ.indigoplugin.HomeKitLink-Siri": {
       "name": "HomeKitLink Siri",
-      "github": "Ghawken/HomeKitLink-Siri"
+      "github": "Ghawken/HomeKitLink-Siri",
+      "store_url": "https://www.indigodomo.com/pluginstore/270/",
+      "store_download": "https://api.github.com/repos/Ghawken/HomeKitLink-Siri/zipball/0.8.05"
     },
     "com.GlennNZ.indigoplugin.ParadoxAlarm": {
       "name": "Paradox Alarm",
-      "github": "ghawken/SpectrumIndigo"
+      "github": "ghawken/SpectrumIndigo",
+      "store_url": "https://www.indigodomo.com/pluginstore/235/",
+      "store_download": "https://api.github.com/repos/Ghawken/SpectrumIndigo/zipball/0.3.2"
     },
     "com.GlennNZ.indigoplugin.SimpleLED": {
       "name": "LED Simple Effects",
-      "github": "ghawken/Indigo-SimpleLED"
+      "github": "ghawken/Indigo-SimpleLED",
+      "store_url": "https://www.indigodomo.com/pluginstore/131/",
+      "store_download": "https://api.github.com/repos/Ghawken/Indigo-SimpleLED/zipball/0.3.0"
     },
     "com.GlennNZ.indigoplugin.SolarSmart": {
       "name": "SolarSmart",
-      "github": "ghawken/SolarSmartPlugin"
+      "github": "ghawken/SolarSmartPlugin",
+      "store_url": "https://www.indigodomo.com/pluginstore/304/",
+      "store_download": "https://api.github.com/repos/Ghawken/SolarSmartPlugin/zipball/1.0.82"
     },
     "com.GlennNZ.indigoplugin.SunRise": {
       "name": "SunRise Device Plugin",
-      "github": "ghawken/Indigo-Sunrise-Plugin"
+      "github": "ghawken/Indigo-Sunrise-Plugin",
+      "store_url": "https://www.indigodomo.com/pluginstore/257/",
+      "store_download": "https://api.github.com/repos/Ghawken/Indigo-Sunrise-Plugin/zipball/0.1.0"
     },
     "com.GlennNZ.indigoplugin.TeslaBattery": {
       "name": "Tesla Battery",
-      "github": "ghawken/TeslaBatteryPlugin"
+      "github": "ghawken/TeslaBatteryPlugin",
+      "store_url": "https://www.indigodomo.com/pluginstore/170/",
+      "store_download": "https://api.github.com/repos/Ghawken/TeslaBatteryPlugin/zipball/1.0.16"
     },
     "com.GlennNZ.indigoplugin.WinRemote": {
       "name": "WinRemote Plugin",
-      "github": "Ghawken/IndigoPlugin-WinRemote"
+      "github": "Ghawken/IndigoPlugin-WinRemote",
+      "store_url": "https://www.indigodomo.com/pluginstore/160/",
+      "store_download": "https://api.github.com/repos/Ghawken/IndigoPlugin-WinRemote/zipball/0.9.16"
     },
     "com.GlennNZ.indigoplugin.appleTV": {
       "name": "appleTV Plugin",
-      "github": "Ghawken/appleTV-indigoPlugin"
+      "github": "Ghawken/appleTV-indigoPlugin",
+      "store_url": "https://www.indigodomo.com/pluginstore/283/",
+      "store_download": "https://api.github.com/repos/Ghawken/appleTV-indigoPlugin/zipball/1.7.10"
     },
     "com.GlennNZ.indigoplugin.deluxeGraphing": {
       "name": "Deluxe Graphing",
-      "github": "ghawken/DeluxeGraphing"
+      "github": "ghawken/DeluxeGraphing",
+      "store_url": "https://www.indigodomo.com/pluginstore/315/",
+      "store_download": "https://api.github.com/repos/Ghawken/DeluxeGraphing/zipball/1.1.20"
     },
     "com.GlennNZ.indigoplugin.device-timer": {
       "name": "Device Timer",
-      "github": "ghawken/Device_Timer_Plugin"
+      "github": "ghawken/Device_Timer_Plugin",
+      "store_url": "https://www.indigodomo.com/pluginstore/302/",
+      "store_download": "https://api.github.com/repos/Ghawken/Device_Timer_Plugin/zipball/2025.1.70"
     },
     "com.GlennNZ.indigoplugin.dreame_vacuum": {
       "name": "Dreame Vacuum Plugin",
-      "github": "ghawken/Dreame-Indigo"
+      "github": "ghawken/Dreame-Indigo",
+      "store_url": "https://www.indigodomo.com/pluginstore/311/",
+      "store_download": "https://api.github.com/repos/Ghawken/Dreame-Indigo/zipball/2025.1.35"
     },
     "com.GlennNZ.indigoplugin.evsemaster": {
       "name": "EVSE Master Charger",
-      "github": "ghawken/EVSEMaster-Plugin"
+      "github": "ghawken/EVSEMaster-Plugin",
+      "store_url": "https://www.indigodomo.com/pluginstore/308/",
+      "store_download": "https://api.github.com/repos/Ghawken/EVSEMaster-Plugin/zipball/2025.1.8"
     },
     "com.GlennNZ.indigoplugin.geckoSpa": {
       "name": "Gecko inTouch Spa Plugin",
-      "github": "ghawken/Indigo-GeckoSPA"
+      "github": "ghawken/Indigo-GeckoSPA",
+      "store_url": "https://www.indigodomo.com/pluginstore/272/",
+      "store_download": "https://api.github.com/repos/Ghawken/Indigo-GeckoSPA/zipball/0.1.44"
     },
     "com.GlennNZ.indigoplugin.holiday": {
       "name": "Holiday",
-      "github": "Ghawken/Holiday"
+      "github": "Ghawken/Holiday",
+      "store_url": "https://www.indigodomo.com/pluginstore/297/",
+      "store_download": "https://api.github.com/repos/Ghawken/Holiday/zipball/0.1.12"
     },
     "com.GlennNZ.indigoplugin.iMessage": {
       "name": "iMessage Plugin",
-      "github": "Ghawken/iMessagePlugin"
+      "github": "Ghawken/iMessagePlugin",
+      "store_url": "https://www.indigodomo.com/pluginstore/195/",
+      "store_download": "https://api.github.com/repos/Ghawken/iMessagePlugin/zipball/0.7.27"
     },
     "com.GlennNZ.indigoplugin.irobot": {
       "name": "iRobot-Roomba",
-      "github": "ghawken/Indigo-iRobotRoomba"
+      "github": "ghawken/Indigo-iRobotRoomba",
+      "store_url": "https://www.indigodomo.com/pluginstore/132/",
+      "store_download": "https://api.github.com/repos/Ghawken/Indigo-iRobotRoomba/zipball/0.10.02"
     },
     "com.GlennNZ.indigoplugin.mammotion": {
       "name": "Mammotion Mower",
-      "github": "ghawken/MammotionPlugin"
+      "github": "ghawken/MammotionPlugin",
+      "store_url": "https://www.indigodomo.com/pluginstore/309/",
+      "store_download": "https://api.github.com/repos/Ghawken/MammotionPlugin/zipball/2025.1.50"
     },
     "com.JohnBurgess.indigoplugin.TP-Link-Device": {
       "name": "TP-Link Device",
-      "github": "jtburgess/indigo-TP-Link"
+      "github": "jtburgess/indigo-TP-Link",
+      "store_url": "https://www.indigodomo.com/pluginstore/188/",
+      "store_download": "https://github.com/jtburgess/indigo-TP-LInk/releases/download/1.0.1/TP-Link-Device.indigoPlugin.zip"
     },
     "com.anyone.indigoplugin.apc-pdu-control": {
       "name": "APC PDU Control",
-      "github": "anyone2/IndigoPlugin-APC-PDU-Control"
+      "github": "anyone2/IndigoPlugin-APC-PDU-Control",
+      "store_url": "https://www.indigodomo.com/pluginstore/271/",
+      "store_download": "https://github.com/anyone2/IndigoPlugin-APC-PDU-Control/releases/download/2022.1.0/APC.PDU.Control.indigoPlugin.zip"
     },
     "com.anyone.indigoplugin.voice-monkey": {
       "name": "Voice Monkey",
-      "github": "anyone2/IndigoPlugin-Voice-Monkey"
+      "github": "anyone2/IndigoPlugin-Voice-Monkey",
+      "store_url": "https://www.indigodomo.com/pluginstore/280/",
+      "store_download": "https://github.com/anyone2/IndigoPlugin-Voice-Monkey/releases/download/2022.1.7/Voice.Monkey.indigoPlugin.zip"
     },
     "com.autologplugin.awtrix3": {
       "name": "AWTRIX 3",
-      "github": "autolog/AWTRIX"
+      "github": "autolog/AWTRIX",
+      "store_url": "https://www.indigodomo.com/pluginstore/318/",
+      "store_download": "https://github.com/autolog/AWTRIX/releases/download/v2026.0.2/AWTRIX.indigoPlugin.zip"
     },
     "com.autologplugin.indigoplugin.dynamicviewcontroller": {
       "name": "Dynamic View Controller",
-      "github": "autolog/Dynamic_View_Controller"
+      "github": "autolog/Dynamic_View_Controller",
+      "store_url": "https://www.indigodomo.com/pluginstore/56/",
+      "store_download": "https://github.com/autolog/Dynamic_View_Controller/releases/download/2023.0.4/dynamicView.indigoPlugin.zip"
     },
     "com.autologplugin.indigoplugin.foscamhdcontroller": {
       "name": "Foscam HD Controller",
-      "github": "autolog/Foscam_HD_Controller"
+      "github": "autolog/Foscam_HD_Controller",
+      "store_url": "https://www.indigodomo.com/pluginstore/53/",
+      "store_download": "https://github.com/autolog/Foscam_HD_Controller/releases/download/2023.0.4/foscamHD.indigoPlugin.zip"
     },
     "com.autologplugin.indigoplugin.hubitat": {
       "name": "Hubitat Bridge",
-      "github": "Autolog/Hubitat_Bridge"
+      "github": "Autolog/Hubitat_Bridge",
+      "store_url": "https://www.indigodomo.com/pluginstore/252/",
+      "store_download": "https://github.com/autolog/Hubitat_Bridge/releases/download/2024.0.3/Hubitat.indigoPlugin.zip"
     },
     "com.autologplugin.indigoplugin.lifxcontroller": {
       "name": "LIFX",
-      "github": "autolog/LIFX_Controller"
+      "github": "autolog/LIFX_Controller",
+      "store_url": "https://www.indigodomo.com/pluginstore/28/",
+      "store_download": "https://github.com/autolog/LIFX_Controller/releases/download/2026.0.1/LIFX.indigoPlugin.zip"
     },
     "com.autologplugin.indigoplugin.nanoleafcontroller": {
       "name": "Nanoleaf",
-      "github": "autolog/nanoleaf_Controller"
+      "github": "autolog/nanoleaf_Controller",
+      "store_url": "https://www.indigodomo.com/pluginstore/29/",
+      "store_download": "https://github.com/autolog/nanoleaf_Controller/releases/download/2022.0.4/nanoleaf.indigoPlugin.zip"
     },
     "com.autologplugin.indigoplugin.rooncontroller": {
       "name": "Roon",
-      "github": "autolog/Roon_Controller"
+      "github": "autolog/Roon_Controller",
+      "store_url": "https://www.indigodomo.com/pluginstore/220/",
+      "store_download": "https://github.com/autolog/Roon_Controller/releases/download/2022.0.0/Roon.indigoPlugin.zip"
     },
     "com.autologplugin.indigoplugin.smappeecontroller": {
       "name": "Smappee",
-      "github": "autolog/Smappee"
+      "github": "autolog/Smappee",
+      "store_url": "https://www.indigodomo.com/pluginstore/52/",
+      "store_download": "https://github.com/autolog/Smappee/releases/download/2023.0.4/Smappee.indigoPlugin.zip"
     },
     "com.autologplugin.indigoplugin.starlingBridge": {
       "name": "Starling Bridge",
-      "github": "autolog/Starling_Bridge"
+      "github": "autolog/Starling_Bridge",
+      "store_url": "https://www.indigodomo.com/pluginstore/275/",
+      "store_download": "https://github.com/autolog/Starling_Bridge/releases/download/2024.0.1/Starling.indigoPlugin.zip"
     },
     "com.autologplugin.indigoplugin.trvcontroller": {
       "name": "TRV",
-      "github": "autolog/TRV_Controller"
+      "github": "autolog/TRV_Controller",
+      "store_url": "https://www.indigodomo.com/pluginstore/201/",
+      "store_download": "https://github.com/autolog/TRV_Controller/releases/download/2022.0.12/TRV.indigoPlugin.zip"
     },
     "com.autologplugin.indigoplugin.zigbee2mqtt": {
       "name": "Zigbee2mqtt Bridge",
-      "github": "autolog/zigbee2mqtt_Bridge"
+      "github": "autolog/zigbee2mqtt_Bridge",
+      "store_url": "https://www.indigodomo.com/pluginstore/281/",
+      "store_download": "https://github.com/autolog/zigbee2mqtt_Bridge/releases/download/2026.0.2/zigbee2mqtt.indigoPlugin.zip"
     },
     "com.autologplugin.indigoplugin.zwaveinterpreter": {
       "name": "Z-Wave Interpreter",
-      "github": "autolog/Z-Wave_Interpreter"
+      "github": "autolog/Z-Wave_Interpreter",
+      "store_url": "https://www.indigodomo.com/pluginstore/253/",
+      "store_download": "https://github.com/autolog/Z-Wave_Interpreter/releases/download/2022.0.0/Z-Wave_Interpreter.indigoPlugin.zip"
     },
     "com.barn.indigoplugin.Daikin-Wifi": {
       "name": "Daikin Wifi Controller",
-      "github": "neilkplugins/Daikin-Wifi-indigo-plugin"
+      "github": "neilkplugins/Daikin-Wifi-indigo-plugin",
+      "store_url": "https://www.indigodomo.com/pluginstore/264/",
+      "store_download": "https://github.com/neilkplugins/Daikin-Wifi-indigo-plugin/releases/download/2022.0.1/Daikin.Wifi.indigoPlugin.zip"
     },
     "com.barn.indigoplugin.GlowmarktCAD": {
       "name": "GlowmarktCAD",
-      "github": "neilkplugins/Glow-IHD-CAD-indigo-plugin"
+      "github": "neilkplugins/Glow-IHD-CAD-indigo-plugin",
+      "store_url": "https://www.indigodomo.com/pluginstore/238/",
+      "store_download": "https://github.com/neilkplugins/Glow-IHD-CAD-indigo-plugin/releases/download/2022.0.1/GlowmarktCAD.indigoPlugin.zip"
     },
     "com.barn.indigoplugin.Honeywell_Evohome": {
       "name": "Evohome",
-      "github": "neilkplugins/evohome-indigo-plugin"
+      "github": "neilkplugins/evohome-indigo-plugin",
+      "store_url": "https://www.indigodomo.com/pluginstore/294/",
+      "store_download": "https://github.com/neilkplugins/evohome-indigo-plugin/releases/download/2023.0.2/Honeywell_Evohome.indigoPlugin.zip"
     },
     "com.barn.indigoplugin.Solcast": {
       "name": "Solcast",
-      "github": "neilkplugins/Solcast-indigo-plugin"
+      "github": "neilkplugins/Solcast-indigo-plugin",
+      "store_url": "https://www.indigodomo.com/pluginstore/265/",
+      "store_download": "https://github.com/neilkplugins/Solcast-indigo-plugin/releases/download/2022.0.2/Solcast.indigoPlugin.zip"
     },
     "com.barn.indigoplugin.VeluxActive": {
       "name": "Velux Active",
-      "github": "neilkplugins/VeluxActive-indigo-plugin"
+      "github": "neilkplugins/VeluxActive-indigo-plugin",
+      "store_url": "https://www.indigodomo.com/pluginstore/288/",
+      "store_download": "https://github.com/neilkplugins/VeluxActive-indigo-plugin/releases/download/2023.0.5/VeluxActive.indigoPlugin.zip"
     },
     "com.barn.indigoplugin.WLED": {
       "name": "WLED",
-      "github": "neilkplugins/WLED-indigo-plugin"
+      "github": "neilkplugins/WLED-indigo-plugin",
+      "store_url": "https://www.indigodomo.com/pluginstore/214/",
+      "store_download": "https://github.com/neilkplugins/WLED-indigo-plugin/releases/download/2023.0.1/WLED.indigoPlugin.zip"
     },
     "com.berkinet.ad2usb": {
       "name": "AD2USB Alarm Interface",
-      "github": "bla260/ad2usb"
+      "github": "bla260/ad2usb",
+      "store_url": "https://www.indigodomo.com/pluginstore/87/",
+      "store_download": "https://github.com/bla260/ad2usb/releases/download/3.4.2/ad2usb.indigoPlugin.zip"
     },
     "com.boisypitre.vss": {
       "name": "VSS - Virtual Security System",
-      "github": "boisy/VSS"
+      "github": "boisy/VSS",
+      "store_url": "https://www.indigodomo.com/pluginstore/266/",
+      "store_download": "https://api.github.com/repos/boisy/VSS/zipball/2022.1.0"
     },
     "com.drjason.temp-adapter": {
       "name": "Adapters",
-      "github": "IndigoDomotics/adapters"
+      "github": "IndigoDomotics/adapters",
+      "store_url": "https://www.indigodomo.com/pluginstore/100/",
+      "store_download": "https://github.com/IndigoDomotics/adapters/releases/download/2023.2.0/Adapters.indigoPlugin.zip"
     },
     "com.duncanware.daytonAudioController": {
       "name": "Dayton Audio Controller",
-      "github": "RogueProeliator/indigo-plugins-dayton-audio"
+      "github": "RogueProeliator/indigo-plugins-dayton-audio",
+      "store_url": "https://www.indigodomo.com/pluginstore/291/",
+      "store_download": "https://github.com/RogueProeliator/indigo-plugins-dayton-audio/releases/download/v2026.1.0/Dayton.Audio.Controller.indigoPlugin.zip"
     },
     "com.duncanware.domoPadMobileClient": {
       "name": "Domotics Pad Mobile Client",
-      "github": "RogueProeliator/indigo-plugins-googleclients"
+      "github": "RogueProeliator/indigo-plugins-googleclients",
+      "store_url": "https://www.indigodomo.com/pluginstore/204/",
+      "store_download": "https://github.com/RogueProeliator/indigo-plugins-googleclients/releases/download/v2024.3.0/DomoPad.Mobile.Client.Plugin.indigoPlugin.zip"
     },
     "com.duncanware.nilesAudioReceiver": {
       "name": "Niles Audio Receiver Plugin",
-      "github": "RogueProeliator/indigo-plugins-nilesaudio"
+      "github": "RogueProeliator/indigo-plugins-nilesaudio",
+      "store_url": "https://www.indigodomo.com/pluginstore/205/",
+      "store_download": "https://github.com/RogueProeliator/indigo-plugins-nilesaudio/releases/download/v2026.1.0/Niles.Audio.Receiver.indigoPlugin.zip"
     },
     "com.duncanware.onkyoNetworkRemote": {
       "name": "Onkyo Network Remote Plugin",
-      "github": "RogueProeliator/indigo-plugins-onkyo-receiver"
+      "github": "RogueProeliator/indigo-plugins-onkyo-receiver",
+      "store_url": "https://www.indigodomo.com/pluginstore/104/",
+      "store_download": "https://github.com/RogueProeliator/indigo-plugins-onkyo-receiver/releases/download/v2024.6.1/Onkyo.Network.Remote.indigoPlugin.zip"
     },
     "com.duncanware.plexMediaServerManager": {
       "name": "Plex Media Server Manager",
-      "github": "RogueProeliator/indigo-plugins-plex-server-manager"
+      "github": "RogueProeliator/indigo-plugins-plex-server-manager",
+      "store_url": "https://www.indigodomo.com/pluginstore/106/",
+      "store_download": "https://github.com/RogueProeliator/indigo-plugins-plex-server-manager/releases/download/v2026.1.0/Plex.Media.Server.Manager.indigoPlugin.zip"
     },
     "com.duncanware.rokuNetworkRemote": {
       "name": "Roku Network Remote",
-      "github": "RogueProeliator/indigo-plugins-roku"
+      "github": "RogueProeliator/indigo-plugins-roku",
+      "store_url": "https://www.indigodomo.com/pluginstore/50/",
+      "store_download": "https://github.com/RogueProeliator/indigo-plugins-roku/releases/download/v2026.1.0/Roku.Network.Remote.indigoPlugin.zip"
     },
     "com.duncanware.sharpTvNetworkRemote": {
       "name": "Sharp TV Network Remote Plugin",
-      "github": "RogueProeliator/IndigoPlugins-Sharp-TV-Network-Remote"
+      "github": "RogueProeliator/IndigoPlugins-Sharp-TV-Network-Remote",
+      "store_url": "https://www.indigodomo.com/pluginstore/206/",
+      "store_download": "https://github.com/RogueProeliator/indigo-plugins-sharptv/releases/download/v2024.6.0/Sharp.TV.Network.Remote.indigoPlugin.zip"
     },
     "com.durosity.indigoplugin.lighttools": {
       "name": "LightTools",
-      "github": "durosity/Indigo-LightTools"
+      "github": "durosity/Indigo-LightTools",
+      "store_url": "https://www.indigodomo.com/pluginstore/312/",
+      "store_download": "https://github.com/durosity/Indigo-LightTools/releases/download/v1.5.1/LightTools.indigoPlugin.zip"
     },
     "com.durosity.indigoplugin.renault": {
       "name": "Renault Car",
-      "github": "Durosity/Indigo-Renault-Car"
+      "github": "Durosity/Indigo-Renault-Car",
+      "store_url": "https://www.indigodomo.com/pluginstore/314/",
+      "store_download": "https://github.com/durosity/Indigo-Renault-Car/releases/download/v1.2.4/RenaultCar.indigoPlugin.zip"
     },
     "com.flyingdiver.indigoplugin.bondhome": {
       "name": "Bond Home",
-      "github": "FlyingDiver/Indigo-BondHome"
+      "github": "FlyingDiver/Indigo-BondHome",
+      "store_url": "https://www.indigodomo.com/pluginstore/219/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-BondHome/releases/download/2025.0.3/BondHome.indigoPlugin.zip"
     },
     "com.flyingdiver.indigoplugin.camect": {
       "name": "Camect",
-      "github": "FlyingDiver/Indigo-Camect"
+      "github": "FlyingDiver/Indigo-Camect",
+      "store_url": "https://www.indigodomo.com/pluginstore/258/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-Camect/releases/download/2022.0.0/Camect.indigoPlugin.zip"
     },
     "com.flyingdiver.indigoplugin.ecobee": {
       "name": "Ecobee 2",
-      "github": "FlyingDiver/Indigo-Ecobee-2"
+      "github": "FlyingDiver/Indigo-Ecobee-2",
+      "store_url": "https://www.indigodomo.com/pluginstore/193/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-Ecobee-2/releases/download/2025.0.1/Ecobee.2.indigoPlugin.zip"
     },
     "com.flyingdiver.indigoplugin.fireboard": {
       "name": "Fireboard",
-      "github": "FlyingDiver/Indigo-FireBoard"
+      "github": "FlyingDiver/Indigo-FireBoard",
+      "store_url": "https://www.indigodomo.com/pluginstore/261/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-FireBoard/releases/download/2022.0.2/Fireboard.indigoPlugin.zip"
     },
     "com.flyingdiver.indigoplugin.ftp": {
       "name": "FTP",
-      "github": "FlyingDiver/Indigo-FTP"
+      "github": "FlyingDiver/Indigo-FTP",
+      "store_url": "https://www.indigodomo.com/pluginstore/61/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-FTP/releases/download/2022.0.0/FTP.indigoPlugin.zip"
     },
     "com.flyingdiver.indigoplugin.harmonyhub": {
       "name": "Harmony Hub",
-      "github": "FlyingDiver/Indigo-Harmony"
+      "github": "FlyingDiver/Indigo-Harmony",
+      "store_url": "https://www.indigodomo.com/pluginstore/32/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-Harmony/releases/download/2025.0.2/HarmonyHub.indigoPlugin.zip"
     },
     "com.flyingdiver.indigoplugin.httpd2": {
       "name": "HTTPd 2",
-      "github": "FlyingDiver/Indigo-HTTPd-2"
+      "github": "FlyingDiver/Indigo-HTTPd-2",
+      "store_url": "https://www.indigodomo.com/pluginstore/222/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-HTTPd-2/releases/download/2022.0.1/HTTPd2.indigoPlugin.zip"
     },
     "com.flyingdiver.indigoplugin.lifxbridge": {
       "name": "LIFX Bridge",
-      "github": "FlyingDiver/Indigo-lifx-bridge"
+      "github": "FlyingDiver/Indigo-lifx-bridge",
+      "store_url": "https://www.indigodomo.com/pluginstore/33/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-lifx-bridge/releases/download/2022.0.0/LIFXBridge.indigoPlugin.zip"
     },
     "com.flyingdiver.indigoplugin.lutron-leap": {
       "name": "Lutron Leap",
-      "github": "FlyingDiver/Indigo-Lutron-Leap"
+      "github": "FlyingDiver/Indigo-Lutron-Leap",
+      "store_url": "https://www.indigodomo.com/pluginstore/278/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-Lutron-Leap/releases/download/2025.0.1/Lutron.Leap.indigoPlugin.zip"
     },
     "com.flyingdiver.indigoplugin.masquerade": {
       "name": "Masquerade",
-      "github": "FlyingDiver/Indigo-Masquerade"
+      "github": "FlyingDiver/Indigo-Masquerade",
+      "store_url": "https://www.indigodomo.com/pluginstore/34/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-Masquerade/releases/download/2022.0.4/Masquerade.indigoPlugin.zip"
     },
     "com.flyingdiver.indigoplugin.miniPurple": {
       "name": "miniPurple",
-      "github": "FlyingDiver/Indigo-miniPurple"
+      "github": "FlyingDiver/Indigo-miniPurple",
+      "store_url": "https://www.indigodomo.com/pluginstore/262/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-miniPurple/releases/download/2022.1.1/miniPurple.indigoPlugin.zip"
     },
     "com.flyingdiver.indigoplugin.miniUniFi": {
       "name": "miniUniFi",
-      "github": "FlyingDiver/Indigo-miniUniFi"
+      "github": "FlyingDiver/Indigo-miniUniFi",
+      "store_url": "https://www.indigodomo.com/pluginstore/243/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-miniUniFi/releases/download/2022.1.3/miniUniFi.indigoPlugin.zip"
     },
     "com.flyingdiver.indigoplugin.miniserial": {
       "name": "miniSerial",
-      "github": "FlyingDiver/Indigo-miniSerial"
+      "github": "FlyingDiver/Indigo-miniSerial",
+      "store_url": "https://www.indigodomo.com/pluginstore/295/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-miniSerial/releases/download/2023.0.1/miniSerial.indigoPlugin.zip"
     },
     "com.flyingdiver.indigoplugin.mqtt": {
       "name": "MQTT Connector",
-      "github": "FlyingDiver/Indigo-MQTT"
+      "github": "FlyingDiver/Indigo-MQTT",
+      "store_url": "https://www.indigodomo.com/pluginstore/211/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-MQTT/releases/download/2023.2.1/MQTT.Connector.indigoPlugin.zip"
     },
     "com.flyingdiver.indigoplugin.mqtt-broker": {
       "name": "MQTT Broker",
-      "github": "FlyingDiver/Indigo-MQTT-Broker"
+      "github": "FlyingDiver/Indigo-MQTT-Broker",
+      "store_url": "https://www.indigodomo.com/pluginstore/260/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-MQTT-Broker/releases/download/2023.2.1/MQTT.Broker.indigoPlugin.zip"
     },
     "com.flyingdiver.indigoplugin.occupatum": {
       "name": "Occupatum",
-      "github": "FlyingDiver/Indigo-Occupatum"
+      "github": "FlyingDiver/Indigo-Occupatum",
+      "store_url": "https://www.indigodomo.com/pluginstore/263/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-Occupatum/releases/download/2022.1.7/Occupatum.indigoPlugin.zip"
     },
     "com.flyingdiver.indigoplugin.pushsafer": {
       "name": "Pushsafer",
-      "github": "IndigoDomotics/indigo-pushsafer"
+      "github": "IndigoDomotics/indigo-pushsafer",
+      "store_url": "https://www.indigodomo.com/pluginstore/161/",
+      "store_download": "https://github.com/IndigoDomotics/indigo-pushsafer/releases/download/2022.1.0/pushsafer.indigoPlugin.zip"
     },
     "com.flyingdiver.indigoplugin.ratgdo": {
       "name": "ratgdo GDO Controller",
-      "github": "FlyingDiver/Indigo-ratgdo"
+      "github": "FlyingDiver/Indigo-ratgdo",
+      "store_url": "https://www.indigodomo.com/pluginstore/296/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-ratgdo/releases/download/2023.2.0/ratgdo.indigoPlugin.zip"
     },
     "com.flyingdiver.indigoplugin.schlageencode": {
       "name": "Schlage Encode",
-      "github": "FlyingDiver/Indigo-Schlage"
+      "github": "FlyingDiver/Indigo-Schlage",
+      "store_url": "https://www.indigodomo.com/pluginstore/306/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-Schlage/releases/download/2025.0.3/SchlageEncode.indigoPlugin.zip"
     },
     "com.flyingdiver.indigoplugin.shims": {
       "name": "MQTT Shims",
-      "github": "FlyingDiver/Indigo-Shims"
+      "github": "FlyingDiver/Indigo-Shims",
+      "store_url": "https://www.indigodomo.com/pluginstore/210/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-Shims/releases/download/2023.2.2/MQTT.Shims.indigoPlugin.zip"
     },
     "com.flyingdiver.indigoplugin.slack": {
       "name": "Slack 2",
-      "github": "FlyingDiver/Indigo-Slack2"
+      "github": "FlyingDiver/Indigo-Slack2",
+      "store_url": "https://www.indigodomo.com/pluginstore/192/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-Slack2/releases/download/2023.2.0/Slack2.indigoPlugin.zip"
     },
     "com.flyingdiver.indigoplugin.smtpd": {
       "name": "SMTPd",
-      "github": "FlyingDiver/Indigo-SMTPd"
+      "github": "FlyingDiver/Indigo-SMTPd",
+      "store_url": "https://www.indigodomo.com/pluginstore/63/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-SMTPd/releases/download/2023.2.0/SMTPd.indigoPlugin.zip"
     },
     "com.flyingdiver.indigoplugin.tankutility": {
       "name": "TankUtility",
-      "github": "FlyingDiver/Indigo-TankUtility"
+      "github": "FlyingDiver/Indigo-TankUtility",
+      "store_url": "https://www.indigodomo.com/pluginstore/171/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-TankUtility/releases/download/2022.0.0/TankUtility.indigoPlugin.zip"
     },
     "com.flyingdiver.indigoplugin.trane-nexia": {
       "name": "Trane Home",
-      "github": "FlyingDiver/Indigo-Trane-Nexia"
+      "github": "FlyingDiver/Indigo-Trane-Nexia",
+      "store_url": "https://www.indigodomo.com/pluginstore/242/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-Trane-Nexia/releases/download/2023.2.0/Trane.Home.indigoPlugin.zip"
     },
     "com.flyingdiver.indigoplugin.twilio": {
       "name": "Twilio",
-      "github": "FlyingDiver/Indigo-Twilio"
+      "github": "FlyingDiver/Indigo-Twilio",
+      "store_url": "https://www.indigodomo.com/pluginstore/26/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-Twilio/releases/download/2024.0.1/Twilio.indigoPlugin.zip"
     },
     "com.flyingdiver.indigoplugin.weatherlink-live": {
       "name": "WeatherLink Live",
-      "github": "FlyingDiver/Indigo-WeatherLinkLive"
+      "github": "FlyingDiver/Indigo-WeatherLinkLive",
+      "store_url": "https://www.indigodomo.com/pluginstore/208/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-WeatherLinkLive/releases/download/2022.0.0/WeatherLink.Live.indigoPlugin.zip"
     },
     "com.fogbert.indigoplugin.GhostXML": {
       "name": "GhostXML",
-      "github": "IndigoDomotics/GhostXML"
+      "github": "IndigoDomotics/GhostXML",
+      "store_url": "https://www.indigodomo.com/pluginstore/38/",
+      "store_download": "https://github.com/IndigoDomotics/GhostXML/releases/download/2024.1.01/GhostXML.indigoPlugin.zip"
     },
     "com.fogbert.indigoplugin.OWServer": {
       "name": "OWServer",
-      "github": "DaveL17/OWServer"
+      "github": "DaveL17/OWServer",
+      "store_url": "https://www.indigodomo.com/pluginstore/98/",
+      "store_download": "https://github.com/DaveL17/OWServer/releases/download/2022.0.2/OWserver.indigoPlugin.zip"
     },
     "com.fogbert.indigoplugin.announcements": {
       "name": "Announcements",
-      "github": "DaveL17/Announcements"
+      "github": "DaveL17/Announcements",
+      "store_url": "https://www.indigodomo.com/pluginstore/141/",
+      "store_download": "https://github.com/DaveL17/Announcements/releases/download/2025.1.0/Announcements.indigoPlugin.zip"
     },
     "com.fogbert.indigoplugin.bikeShare": {
       "name": "Bike Share",
-      "github": "DaveL17/BikeShare"
+      "github": "DaveL17/BikeShare",
+      "store_url": "https://www.indigodomo.com/pluginstore/41/",
+      "store_download": "https://github.com/DaveL17/BikeShare/releases/download/2025.1.0/Bike.Share.indigoPlugin.zip"
     },
     "com.fogbert.indigoplugin.fantasticwWeather": {
       "name": "Fantastic Weather",
-      "github": "DaveL17/Fantastic-Weather"
+      "github": "DaveL17/Fantastic-Weather",
+      "store_url": "https://www.indigodomo.com/pluginstore/191/",
+      "store_download": "https://github.com/DaveL17/Fantastic-Weather/releases/download/2022.0.6/fantasticWeather.indigoPlugin.zip"
     },
     "com.fogbert.indigoplugin.matplotlib": {
       "name": "Matplotlib",
-      "github": "DaveL17/matplotlib"
+      "github": "DaveL17/matplotlib",
+      "store_url": "https://www.indigodomo.com/pluginstore/27/",
+      "store_download": "https://github.com/DaveL17/matplotlib/releases/download/v2023.0.1/matplotlib.indigoPlugin.zip"
     },
     "com.fogbert.indigoplugin.multitool": {
       "name": "Multitool",
-      "github": "DaveL17/Multitool"
+      "github": "DaveL17/Multitool",
+      "store_url": "https://www.indigodomo.com/pluginstore/145/",
+      "store_download": "https://github.com/DaveL17/Multitool/releases/download/2025.2.2/Multitool.indigoPlugin.zip"
     },
     "com.frightideas.indigoplugin.dscAlarm": {
       "name": "DSC Alarm",
-      "github": "IndigoDomotics/DSC-Alarm"
+      "github": "IndigoDomotics/DSC-Alarm",
+      "store_url": "https://www.indigodomo.com/pluginstore/16/",
+      "store_download": "https://github.com/IndigoDomotics/DSC-Alarm/releases/download/2022.0.6/DSC.Alarm.indigoPlugin.zip"
     },
     "com.github.wonderslug.hassbridge": {
       "name": "HassBridge",
-      "github": "IndigoDomotics/hassbridge"
+      "github": "IndigoDomotics/hassbridge",
+      "store_url": "https://www.indigodomo.com/pluginstore/233/",
+      "store_download": "https://github.com/IndigoDomotics/hassbridge/releases/download/2022.0.5/HassBridge.indigoPlugin.zip"
     },
     "com.heddings.indigo.prowl": {
       "name": "Prowl",
-      "github": "jheddings/indigo-prowl"
+      "github": "jheddings/indigo-prowl",
+      "store_url": "https://www.indigodomo.com/pluginstore/134/",
+      "store_download": "https://github.com/jheddings/indigo-prowl/releases/download/v1.2.0/Prowl.indigoPlugin.zip"
     },
     "com.howartp.clockdisplay": {
       "name": "Clock Display",
-      "github": "howartp84/ClockDisplay"
+      "github": "howartp84/ClockDisplay",
+      "store_url": "https://www.indigodomo.com/pluginstore/164/",
+      "store_download": "https://github.com/howartp84/ClockDisplay/releases/download/3.0.17/ClockDisplay.indigoPlugin.zip"
     },
     "com.howartp.lockmanager": {
       "name": "Z-Wave Lock Manager",
-      "github": "howartp84/ZWaveLockManager"
+      "github": "howartp84/ZWaveLockManager",
+      "store_url": "https://www.indigodomo.com/pluginstore/83/",
+      "store_download": "https://github.com/howartp84/ZWaveLockManager/releases/download/3.0.66/ZwaveLockManager.indigoPlugin.zip"
     },
     "com.howartp.neoblinds": {
       "name": "Neo Blinds",
-      "github": "howartp84/NeoSmartBlinds"
+      "github": "howartp84/NeoSmartBlinds",
+      "store_url": "https://www.indigodomo.com/pluginstore/230/",
+      "store_download": "https://github.com/howartp84/NeoSmartBlinds/releases/download/3.0.7/NeoSmartBlinds.indigoPlugin.zip"
     },
     "com.howartp.scenecontrol": {
       "name": "Z-Wave Scene Controller",
-      "github": "howartp84/ZWaveSceneController"
+      "github": "howartp84/ZWaveSceneController",
+      "store_url": "https://www.indigodomo.com/pluginstore/39/",
+      "store_download": "https://github.com/howartp84/ZWaveSceneController/releases/download/3.0.43/ZwaveSceneController.indigoPlugin.zip"
     },
     "com.howartp.sense": {
       "name": "Sense",
-      "github": "howartp84/Sense"
+      "github": "howartp84/Sense",
+      "store_url": "https://www.indigodomo.com/pluginstore/213/",
+      "store_download": "https://github.com/howartp84/Sense/releases/download/3.0.9/Sense.indigoPlugin.zip"
     },
     "com.howartp.teslacontrol": {
       "name": "Tesla EV Control",
-      "github": "howartp84/TeslaControl"
+      "github": "howartp84/TeslaControl",
+      "store_url": "https://www.indigodomo.com/pluginstore/165/",
+      "store_download": "https://github.com/howartp84/TeslaControl/releases/download/3.0.2/Tesla.Control.indigoPlugin.zip"
     },
     "com.howartp.variabledevice": {
       "name": "Variable Devices",
-      "github": "howartp84/VariableDevice"
+      "github": "howartp84/VariableDevice",
+      "store_url": "https://www.indigodomo.com/pluginstore/269/",
+      "store_download": "https://github.com/howartp84/VariableDevice/releases/download/3.0.7/VariableDevice.indigoPlugin.zip"
     },
     "com.howartp.verisurev2": {
       "name": "Verisure v2",
-      "github": "howartp84/verisure"
+      "github": "howartp84/verisure",
+      "store_url": "https://www.indigodomo.com/pluginstore/216/",
+      "store_download": "https://api.github.com/repos/howartp84/Verisure/zipball/3.0.12"
     },
     "com.howartp.windowcontrol": {
       "name": "Z-Wave Window Controller",
-      "github": "howartp84/ZWaveWindowController"
+      "github": "howartp84/ZWaveWindowController",
+      "store_url": "https://www.indigodomo.com/pluginstore/246/",
+      "store_download": "https://github.com/howartp84/ZWaveWindowController/releases/download/3.0.3/ZwaveWindowController.indigoPlugin.zip"
     },
     "com.howartp.zwavesensorlogger": {
       "name": "Z-Wave Sensor Logger",
-      "github": "howartp84/ZWaveSensorLogger"
+      "github": "howartp84/ZWaveSensorLogger",
+      "store_url": "https://www.indigodomo.com/pluginstore/36/",
+      "store_download": "https://github.com/howartp84/ZwaveSensorLogger/releases/download/3.0.31/ZwaveSensorLogger.indigoPlugin.zip"
     },
     "com.howartp.zwavewatcher": {
       "name": "Z-Wave Watcher",
-      "github": "howartp84/ZWaveWatcher"
+      "github": "howartp84/ZWaveWatcher",
+      "store_url": "https://www.indigodomo.com/pluginstore/43/",
+      "store_download": "https://github.com/howartp84/ZWaveWatcher/releases/download/3.0.9/ZwaveWatcher.indigoPlugin.zip"
     },
     "com.indigodomo.indigoplugin.autologsqueezeboxcontroller": {
       "name": "Squeezebox",
-      "github": "autolog/Squeezebox_Controller"
+      "github": "autolog/Squeezebox_Controller",
+      "store_url": "https://www.indigodomo.com/pluginstore/58/",
+      "store_download": "https://github.com/autolog/Squeezebox_Controller/releases/download/2023.0.7/Squeezebox.indigoPlugin.zip"
     },
     "com.indigodomo.opensource.rachio": {
       "name": "Rachio Sprinklers",
-      "github": "IndigoDomotics/rachio-indigo"
+      "github": "IndigoDomotics/rachio-indigo",
+      "store_url": "https://www.indigodomo.com/pluginstore/12/",
+      "store_download": "https://github.com/IndigoDomotics/rachio-indigo/releases/download/2022.0.2/Rachio.Sprinkler.indigoPlugin.zip"
     },
     "com.jeremyswancoat.indigoplugin.nuvograndconcerto": {
       "name": "NuVo Grand Concerto",
-      "github": "Monstergerm/Indigo-NuvoGrandConcerto"
+      "github": "Monstergerm/Indigo-NuvoGrandConcerto",
+      "store_url": "https://www.indigodomo.com/pluginstore/66/",
+      "store_download": "https://api.github.com/repos/Monstergerm/Indigo-NuvoGrandConcerto/zipball/2022.0.1"
     },
     "com.jeremyswancoat.indigoplugin.pentairpool": {
       "name": "Pentair Pool",
-      "github": "FlyingDiver/Indigo-Pentair"
+      "github": "FlyingDiver/Indigo-Pentair",
+      "store_url": "https://www.indigodomo.com/pluginstore/67/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-Pentair/releases/download/2023.0.1/Pentair.Pool.indigoPlugin.zip"
     },
     "com.jimandnoreen.indigoplugin.lutron-radiora2": {
       "name": "Lutron RRA2/Cas\u00e9ta",
-      "github": "FlyingDiver/Indigo-radiora2"
+      "github": "FlyingDiver/Indigo-radiora2",
+      "store_url": "https://www.indigodomo.com/pluginstore/84/",
+      "store_download": "https://api.github.com/repos/FlyingDiver/Indigo-radiora2/zipball/2022.1.3"
     },
     "com.karlwachs.INDIGOplotD": {
       "name": "INDIGOplotD",
-      "github": "kw123/indigoplotd"
+      "github": "kw123/indigoplotd",
+      "store_url": "https://www.indigodomo.com/pluginstore/71/",
+      "store_download": "https://github.com/kw123/indigoplotd/releases/download/2022.21.92/INDIGOplotD.indigoPlugin.zip"
     },
     "com.karlwachs.VoiceReceiver": {
       "name": "VoiceReceiver",
-      "github": "kw123/VoiceReceiver"
+      "github": "kw123/VoiceReceiver",
+      "store_url": "https://www.indigodomo.com/pluginstore/316/",
+      "store_download": "https://github.com/kw123/VoiceReceiver/releases/download/2022.3.3/VoiceReceiver.indigoPlugin.zip"
     },
     "com.karlwachs.arduino": {
       "name": "arduino",
-      "github": "kw123/arduino"
+      "github": "kw123/arduino",
+      "store_url": "https://www.indigodomo.com/pluginstore/74/",
+      "store_download": "https://github.com/kw123/arduino/releases/download/2022.9.16/arduino.indigoPlugin.zip"
     },
     "com.karlwachs.fingscan": {
       "name": "fingscan",
-      "github": "kw123/fingscan"
+      "github": "kw123/fingscan",
+      "store_url": "https://www.indigodomo.com/pluginstore/72/",
+      "store_download": "https://api.github.com/repos/kw123/fingscan/zipball/2022.40.116"
     },
     "com.karlwachs.homematic": {
       "name": "homematic",
-      "github": "kw123/homematic"
+      "github": "kw123/homematic",
+      "store_url": "https://www.indigodomo.com/pluginstore/292/",
+      "store_download": "https://github.com/kw123/homematic/releases/download/2022.7.8/homematic.indigoPlugin.zip"
     },
     "com.karlwachs.minMax": {
       "name": "minMax",
-      "github": "kw123/minMax"
+      "github": "kw123/minMax",
+      "store_url": "https://www.indigodomo.com/pluginstore/95/",
+      "store_download": "https://github.com/kw123/minMax/releases/download/2022.18.28/minMax.indigoPlugin.zip"
     },
     "com.karlwachs.networkscanner": {
       "name": "Network Scanner",
@@ -470,43 +701,63 @@
     },
     "com.karlwachs.piBeacon": {
       "name": "piBeacon",
-      "github": "kw123/pibeacon"
+      "github": "kw123/pibeacon",
+      "store_url": "https://www.indigodomo.com/pluginstore/59/",
+      "store_download": "https://github.com/kw123/pibeacon/releases/download/2022.191.161/piBeacon.indigoPlugin.zip"
     },
     "com.karlwachs.secondsSinceLastChange": {
       "name": "secondsSinceLastChange",
-      "github": "kw123/secondssincelastchnage"
+      "github": "kw123/secondssincelastchnage",
+      "store_url": "https://www.indigodomo.com/pluginstore/96/",
+      "store_download": "https://api.github.com/repos/kw123/secondssincelastchnage/zipball/2022.1.13"
     },
     "com.karlwachs.shelly": {
       "name": "shelly",
-      "github": "kw123/SHELLY"
+      "github": "kw123/SHELLY",
+      "store_url": "https://www.indigodomo.com/pluginstore/224/",
+      "store_download": "https://github.com/kw123/SHELLY/releases/download/7.20.57/shellyDirect.indigoPlugin.zip"
     },
     "com.karlwachs.shutdownAction": {
       "name": "shutdownAction",
-      "github": "kw123/shutdown-action"
+      "github": "kw123/shutdown-action",
+      "store_url": "https://www.indigodomo.com/pluginstore/190/",
+      "store_download": "https://github.com/kw123/shutdown-action/releases/download/2022.5.5/shutdownAction.indigoPlugin.zip"
     },
     "com.karlwachs.startupAction": {
       "name": "startupAction",
-      "github": "kw123/startupAction"
+      "github": "kw123/startupAction",
+      "store_url": "https://www.indigodomo.com/pluginstore/298/",
+      "store_download": "https://github.com/kw123/startupAction/releases/download/2022.0.3/startupAction.indigoPlugin.zip"
     },
     "com.karlwachs.uniFiAP": {
       "name": "uniFiAP",
-      "github": "kw123/unifi"
+      "github": "kw123/unifi",
+      "store_url": "https://www.indigodomo.com/pluginstore/73/",
+      "store_download": "https://github.com/kw123/unifi/releases/download/2022.49.434/uniFiAP.indigoPlugin.zip"
     },
     "com.karlwachs.utilities": {
       "name": "utilities",
-      "github": "kw123/indigoUtilities"
+      "github": "kw123/indigoUtilities",
+      "store_url": "https://www.indigodomo.com/pluginstore/75/",
+      "store_download": "https://github.com/kw123/indigoUtilities/releases/download/2022.22.45/utilities.indigoPlugin.zip"
     },
     "com.lionsheeptechnology.ShellyMQTT": {
       "name": "ShellyMQTT",
-      "github": "AaronLionsheep/ShellyMQTT"
+      "github": "AaronLionsheep/ShellyMQTT",
+      "store_url": "https://www.indigodomo.com/pluginstore/236/",
+      "store_download": "https://github.com/AaronLionsheep/ShellyMQTT/releases/download/1.1.0/ShellyMQTT.indigoPlugin.zip"
     },
     "com.lionsheeptechnology.ShellyNGMQTT": {
       "name": "ShellyNGMQTT",
-      "github": "AaronLionsheep/ShellyNGMQTT"
+      "github": "AaronLionsheep/ShellyNGMQTT",
+      "store_url": "https://www.indigodomo.com/pluginstore/290/",
+      "store_download": "https://github.com/AaronLionsheep/ShellyNGMQTT/releases/download/1.1.0/ShellyNGMQTT.indigoPlugin.zip"
     },
     "com.lionsheeptechnology.SmartRent": {
       "name": "SmartRent",
-      "github": "AaronLionsheep/SmartRent"
+      "github": "AaronLionsheep/SmartRent",
+      "store_url": "https://www.indigodomo.com/pluginstore/305/",
+      "store_download": "https://github.com/AaronLionsheep/SmartRent/releases/download/v1.0.2/SmartRent.indigoPlugin.zip"
     },
     "com.marcus.indigoplugin.yamaharxaus": {
       "name": "Yamaha RX Receiver AUS",
@@ -515,103 +766,153 @@
     },
     "com.mkuchnic.indigoplugin.schluter": {
       "name": "Schluter Thermostat",
-      "github": "MKuchnic/Indigo-Schluter-1"
+      "github": "MKuchnic/Indigo-Schluter-1",
+      "store_url": "https://www.indigodomo.com/pluginstore/286/",
+      "store_download": "https://github.com/MKuchnic/Indigo-Schluter-1/releases/download/v2023.1.0/Schluter-1.indigoPlugin.zip"
     },
     "com.morris.confirmed-lock": {
       "name": "Confirmed Lock",
-      "github": "kmarkley/Indigo-Confirmed-Lock"
+      "github": "kmarkley/Indigo-Confirmed-Lock",
+      "store_url": "https://www.indigodomo.com/pluginstore/152/",
+      "store_download": "https://github.com/kmarkley/Indigo-Confirmed-Lock/releases/download/0.1.0/Confirmed.Lock.indigoPlugin.zip"
     },
     "com.morris.default-dimmer-level": {
       "name": "Default Dimmer Level",
-      "github": "kmarkley/Indigo-Default-Dimmer"
+      "github": "kmarkley/Indigo-Default-Dimmer",
+      "store_url": "https://www.indigodomo.com/pluginstore/227/",
+      "store_download": "https://github.com/kmarkley/Indigo-Default-Dimmer/releases/download/0.1.0/Default.Dimmer.indigoPlugin.zip"
     },
     "com.morris.fan-group": {
       "name": "Fan Group",
-      "github": "kmarkley/Indigo-Fan-Group"
+      "github": "kmarkley/Indigo-Fan-Group",
+      "store_url": "https://www.indigodomo.com/pluginstore/89/",
+      "store_download": "https://github.com/kmarkley/Indigo-Fan-Group/releases/download/0.1.0/Fan.Group.indigoPlugin.zip"
     },
     "com.morris.google-calendar": {
       "name": "Google Calendar",
-      "github": "kmarkley/Indigo-Google-Calendar"
+      "github": "kmarkley/Indigo-Google-Calendar",
+      "store_url": "https://www.indigodomo.com/pluginstore/226/",
+      "store_download": "https://github.com/kmarkley/Indigo-Google-Calendar/releases/download/0.1.0/Google.Calendar.indigoPlugin.zip"
     },
     "com.morris.group-change-listener": {
       "name": "Group Change Listener",
-      "github": "kmarkley/Indigo-Group-Change-Listener"
+      "github": "kmarkley/Indigo-Group-Change-Listener",
+      "store_url": "https://www.indigodomo.com/pluginstore/153/",
+      "store_download": "https://github.com/kmarkley/Indigo-Group-Change-Listener/releases/download/0.1.0/Group.Change.Listener.indigoPlugin.zip"
     },
     "com.morris.itunes-local-control": {
       "name": "iTunes Local Control",
-      "github": "kmarkley/Indigo-iTunes-Local-Control"
+      "github": "kmarkley/Indigo-iTunes-Local-Control",
+      "store_url": "https://www.indigodomo.com/pluginstore/154/",
+      "store_download": "https://github.com/kmarkley/Indigo-iTunes-Local-Control/releases/download/2022.0.7/iTunes.Local.Control.indigoPlugin.zip"
     },
     "com.morris.lock-group": {
       "name": "Lock Group",
-      "github": "kmarkley/Indigo-Lock-Group"
+      "github": "kmarkley/Indigo-Lock-Group",
+      "store_url": "https://www.indigodomo.com/pluginstore/225/",
+      "store_download": "https://github.com/kmarkley/Indigo-Lock-Group/releases/download/0.1.0/Lock.Group.indigoPlugin.zip"
     },
     "com.morris.mac-apps": {
       "name": "Mac Apps",
-      "github": "kmarkley/Indigo-Mac-Apps"
+      "github": "kmarkley/Indigo-Mac-Apps",
+      "store_url": "https://www.indigodomo.com/pluginstore/92/",
+      "store_download": "https://github.com/kmarkley/Indigo-Mac-Apps/releases/download/0.1.0/Mac.Apps.indigoPlugin.zip"
     },
     "com.morris.neato-botvac": {
       "name": "Neato Botvac",
-      "github": "kmarkley/Indigo-Neato-Botvac"
+      "github": "kmarkley/Indigo-Neato-Botvac",
+      "store_url": "https://www.indigodomo.com/pluginstore/229/",
+      "store_download": "https://github.com/kmarkley/Indigo-Neato-Botvac/releases/download/0.1.0/Neato.Botvac.indigoPlugin.zip"
     },
     "com.morris.online-sensor": {
       "name": "Online Sensor",
-      "github": "kmarkley/Indigo-Online-Sensor"
+      "github": "kmarkley/Indigo-Online-Sensor",
+      "store_url": "https://www.indigodomo.com/pluginstore/90/",
+      "store_download": "https://github.com/kmarkley/Indigo-Online-Sensor/releases/download/0.1.0/Online.Sensor.indigoPlugin.zip"
     },
     "com.morris.over-auto": {
       "name": "Over Auto",
-      "github": "kmarkley/Indigo-Over-Auto"
+      "github": "kmarkley/Indigo-Over-Auto",
+      "store_url": "https://www.indigodomo.com/pluginstore/228/",
+      "store_download": "https://github.com/kmarkley/Indigo-Over-Auto/releases/download/0.1.0/Over.Auto.indigoPlugin.zip"
     },
     "com.morris.realistic-random": {
       "name": "Realistic Random",
-      "github": "kmarkley/Indigo-Realistic-Random"
+      "github": "kmarkley/Indigo-Realistic-Random",
+      "store_url": "https://www.indigodomo.com/pluginstore/94/",
+      "store_download": "https://github.com/kmarkley/Indigo-Realistic-Random/releases/download/0.1.0/Realistic.Random.indigoPlugin.zip"
     },
     "com.morris.sensor-stats": {
       "name": "Sensor Stats",
-      "github": "kmarkley/Indigo-Sensor-Stats"
+      "github": "kmarkley/Indigo-Sensor-Stats",
+      "store_url": "https://www.indigodomo.com/pluginstore/178/",
+      "store_download": "https://github.com/kmarkley/Indigo-Sensor-Stats/releases/download/0.1.0/Sensor.Stats.indigoPlugin.zip"
     },
     "com.morris.state-tree-actions": {
       "name": "State Tree Actions",
-      "github": "kmarkley/Indigo-State-Tree-Actions"
+      "github": "kmarkley/Indigo-State-Tree-Actions",
+      "store_url": "https://www.indigodomo.com/pluginstore/155/",
+      "store_download": "https://github.com/kmarkley/Indigo-State-Tree-Actions/releases/download/0.1.0/State.Tree.Actions.indigoPlugin.zip"
     },
     "com.morris.timed-devices": {
       "name": "Timed Devices",
-      "github": "kmarkley/Indigo-Timed-Devices"
+      "github": "kmarkley/Indigo-Timed-Devices",
+      "store_url": "https://www.indigodomo.com/pluginstore/88/",
+      "store_download": "https://api.github.com/repos/kmarkley/Indigo-Timed-Devices/zipball/0.1.0"
     },
     "com.morris.unistat": {
       "name": "Unistat",
-      "github": "kmarkley/Indigo-Unistat"
+      "github": "kmarkley/Indigo-Unistat",
+      "store_url": "https://www.indigodomo.com/pluginstore/156/",
+      "store_download": "https://github.com/kmarkley/Indigo-Unistat/releases/download/0.1.0/Unistat.indigoPlugin.zip"
     },
     "com.nathansheldon.indigoplugin.HueLights": {
       "name": "Hue Lights",
-      "github": "kw123/Hue-Lights-Indigo-plugin"
+      "github": "kw123/Hue-Lights-Indigo-plugin",
+      "store_url": "https://www.indigodomo.com/pluginstore/21/",
+      "store_download": "https://github.com/kw123/Hue-Lights-Indigo-plugin/releases/download/2022.29.82/Hue.Lights.indigoPlugin.zip"
     },
     "com.nathansheldon.indigoplugin.PioneerReceiver": {
       "name": "Pioneer Receiver",
-      "github": "IndigoDomotics/Pioneer-Receiver-Indigo-Plugin"
+      "github": "IndigoDomotics/Pioneer-Receiver-Indigo-Plugin",
+      "store_url": "https://www.indigodomo.com/pluginstore/45/",
+      "store_download": "https://downloads.indigodomo.com/pluginstore/com.nathansheldon/com.nathansheldon.indigoplugin.PioneerReceiver/2022.0.11/Pioneer_Receiver.indigoPlugin.zip"
     },
     "com.nathansheldon.indigoplugin.sleepybed-iq": {
       "name": "SleepyBed IQ",
-      "github": "IndigoDomotics/SleepyBed-IQ-Indigo-Plugin"
+      "github": "IndigoDomotics/SleepyBed-IQ-Indigo-Plugin",
+      "store_url": "https://www.indigodomo.com/pluginstore/46/",
+      "store_download": "https://github.com/IndigoDomotics/SleepyBed-IQ-Indigo-Plugin/releases/download/2023.0.0/SleepyBed.IQ.indigoPlugin.zip"
     },
     "com.nathanw.IndigoPlugin.ESPHomeClimate": {
       "name": "ESPHome Climate",
-      "github": "nathanjw/ESPHomeClimate-indigo-plugin"
+      "github": "nathanjw/ESPHomeClimate-indigo-plugin",
+      "store_url": "https://www.indigodomo.com/pluginstore/289/",
+      "store_download": "https://github.com/nathanjw/ESPHomeClimate-indigo-plugin/releases/download/v1.1.0/ESPHomeClimate.indigoPlugin.zip"
     },
     "com.pennypacker.indigoplugin.weatherflow": {
       "name": "WeatherFlow Smart Weather",
-      "github": "bpennypacker/WeatherFlow-Indigo-Plugin"
+      "github": "bpennypacker/WeatherFlow-Indigo-Plugin",
+      "store_url": "https://www.indigodomo.com/pluginstore/217/",
+      "store_download": "https://api.github.com/repos/bpennypacker/WeatherFlow-Indigo-Plugin/zipball/v2022.0.1"
     },
     "com.perceptiveautomation.indigoplugin.directvdvrcontrol": {
       "name": "DIRECTV DVR Control",
-      "github": "IndigoDomotics/directv-dvr-control"
+      "github": "IndigoDomotics/directv-dvr-control",
+      "store_url": "https://www.indigodomo.com/pluginstore/2/",
+      "store_download": "https://api.github.com/repos/IndigoDomotics/directv-dvr-control/zipball/2023.0.1"
     },
     "com.perceptiveautomation.indigoplugin.user-scripts": {
       "name": "User Scripts",
-      "github": "IndigoDomotics/indigo-user-scripts"
+      "github": "IndigoDomotics/indigo-user-scripts",
+      "store_url": "https://www.indigodomo.com/pluginstore/150/",
+      "store_download": "https://api.github.com/repos/IndigoDomotics/indigo-user-scripts/zipball/2023.1.0"
     },
     "com.pluginfactory.indigoplugin.rainmachine2": {
       "name": "RainMachine2",
-      "github": "geoffsharris/RainMachine2"
+      "github": "geoffsharris/RainMachine2",
+      "store_url": "https://www.indigodomo.com/pluginstore/277/",
+      "store_download": "https://downloads.indigodomo.com/pluginstore/com.pluginfactory/com.pluginfactory.indigoplugin.rainmachine2/1.0.0/RainMachine2.zip"
     },
     "com.racarter.indigoplugin.blink": {
       "name": "Blink",
@@ -665,135 +966,201 @@
     },
     "com.ramias.indigo.plugins.pihole": {
       "name": "Pi Hole DNS Controller",
-      "github": "Ramias1/indigo-pi-hole"
+      "github": "Ramias1/indigo-pi-hole",
+      "store_url": "https://www.indigodomo.com/pluginstore/203/",
+      "store_download": "https://api.github.com/repos/Ramias1/indigo-pi-hole/zipball/2.1.1"
     },
     "com.ryanbuckner.indigoplugin.life360": {
       "name": "Life360",
-      "github": "ryanbuckner/life360-plugin"
+      "github": "ryanbuckner/life360-plugin",
+      "store_url": "https://www.indigodomo.com/pluginstore/256/",
+      "store_download": "https://downloads.indigodomo.com/pluginstore/com.ryanbuckner/com.ryanbuckner.indigoplugin.life360/2023.1.3/life360.indigoPlugin.zip"
     },
     "com.schollnick.indigoplugin.BatteryMonitor": {
       "name": "UPS and Battery Monitor",
-      "github": "FlyingDiver/Indigo-UPS-Battery-Plugin"
+      "github": "FlyingDiver/Indigo-UPS-Battery-Plugin",
+      "store_url": "https://www.indigodomo.com/pluginstore/108/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-UPS-Battery-Plugin/releases/download/2023.0.0/BatteryMonitor.indigoPlugin.zip"
     },
     "com.sherwinsound.anthemrs232": {
       "name": "Anthem RS232",
-      "github": "Koreysherwin/indigo-anthem-rs232"
+      "github": "Koreysherwin/indigo-anthem-rs232",
+      "store_url": "https://www.indigodomo.com/pluginstore/324/",
+      "store_download": "https://github.com/Koreysherwin/indigo-anthem-rs232/releases/download/v1.0/Anthem-RS232.indigoPlugin.zip"
     },
     "com.sherwinsound.spotifycontrol": {
       "name": "Spotify Control",
-      "github": "Koreysherwin/indigo-spotify-control"
+      "github": "Koreysherwin/indigo-spotify-control",
+      "store_url": "https://www.indigodomo.com/pluginstore/325/",
+      "store_download": "https://github.com/Koreysherwin/indigo-spotify-control/releases/download/v1.0.7/Spotify.Control.indigoPlugin.zip"
     },
     "com.sherwinsound.viewsonicprojector": {
       "name": "ViewSonic Projector",
-      "github": "Koreysherwin/indigo-ViewSonicProjector"
+      "github": "Koreysherwin/indigo-ViewSonicProjector",
+      "store_url": "https://www.indigodomo.com/pluginstore/323/",
+      "store_download": "https://downloads.indigodomo.com/pluginstore/com.sherwinsound/com.sherwinsound.viewsonicprojector/1.4.5/ViewSonicProjector.indigoPlugin.zip"
     },
     "com.simons-plugins.UKTrains": {
       "name": "UK Trains",
-      "github": "simons-plugins/indigo-UKTrains"
+      "github": "simons-plugins/indigo-UKTrains",
+      "store_url": "https://www.indigodomo.com/pluginstore/284/",
+      "store_download": "https://github.com/simons-plugins/indigo-UKTrains/releases/download/v2026.0.3/UKTrains.indigoPlugin.zip"
     },
     "com.simons-plugins.domio": {
       "name": "Domio",
-      "github": "simons-plugins/indigo-domio-plugin"
+      "github": "simons-plugins/indigo-domio-plugin",
+      "store_url": "https://www.indigodomo.com/pluginstore/320/",
+      "store_download": "https://github.com/simons-plugins/indigo-domio-plugin/releases/download/2026.3.2/Domio.indigoPlugin.zip"
     },
     "com.simons-plugins.logs-over-reflector": {
       "name": "LogsOverReflector",
-      "github": "simons-plugins/logs-over-reflector"
+      "github": "simons-plugins/logs-over-reflector",
+      "store_url": "https://www.indigodomo.com/pluginstore/317/",
+      "store_download": "https://github.com/simons-plugins/logs-over-reflector/releases/download/2026.0.3/LogsOverReflector.indigoPlugin.zip"
     },
     "com.simons-plugins.netro": {
       "name": "Netro Sprinklers",
-      "github": "simons-plugins/netro-indigo"
+      "github": "simons-plugins/netro-indigo",
+      "store_url": "https://www.indigodomo.com/pluginstore/282/",
+      "store_download": "https://github.com/simons-plugins/netro-indigo/releases/download/2026.1.2/Netro.Sprinklers.indigoPlugin.zip"
     },
     "com.simons-plugins.sofabaton": {
       "name": "Sofabaton",
-      "github": "simons-plugins/indigo-sofabaton"
+      "github": "simons-plugins/indigo-sofabaton",
+      "store_url": "https://www.indigodomo.com/pluginstore/319/",
+      "store_download": "https://github.com/simons-plugins/indigo-sofabaton/releases/download/2026.0.3/Sofabaton.indigoPlugin.zip"
     },
     "com.smurfless.indigoplugin.json1": {
       "name": "JSON Broadcast Plugin",
-      "github": "smurfless1/indigo-json-broadcaster"
+      "github": "smurfless1/indigo-json-broadcaster",
+      "store_url": "https://www.indigodomo.com/pluginstore/35/",
+      "store_download": "https://api.github.com/repos/smurfless1/indigo-json-broadcaster/zipball/v0.6.2"
     },
     "com.ssi.indigoplugin.Sonos": {
       "name": "Sonos",
-      "github": "IndigoDomotics/Sonos"
+      "github": "IndigoDomotics/Sonos",
+      "store_url": "https://www.indigodomo.com/pluginstore/147/",
+      "store_download": "https://github.com/IndigoDomotics/Sonos/releases/download/2024.0.4/Sonos.indigoPlugin.zip"
     },
     "com.vtmikel.augusthome": {
       "name": "August Home",
-      "github": "mlamoure/Indigo-August-Home"
+      "github": "mlamoure/Indigo-August-Home",
+      "store_url": "https://www.indigodomo.com/pluginstore/103/",
+      "store_download": "https://github.com/mlamoure/Indigo-August-Home/releases/download/v1.1.0/August.Home.indigoPlugin.zip"
     },
     "com.vtmikel.autofan": {
       "name": "Auto Fan",
-      "github": "mlamoure/indigo-auto-fan-plugin"
+      "github": "mlamoure/indigo-auto-fan-plugin",
+      "store_url": "https://www.indigodomo.com/pluginstore/322/",
+      "store_download": "https://github.com/mlamoure/indigo-auto-fan-plugin/releases/download/v2026.1.0/Auto.Fan.indigoPlugin.zip"
     },
     "com.vtmikel.autolights": {
       "name": "Auto Lights",
-      "github": "mlamoure/indigo-auto-lights"
+      "github": "mlamoure/indigo-auto-lights",
+      "store_url": "https://www.indigodomo.com/pluginstore/300/",
+      "store_download": "https://github.com/mlamoure/indigo-auto-lights/releases/download/v2026.1.0/Auto.Lights.indigoPlugin.zip"
     },
     "com.vtmikel.grafana": {
       "name": "Grafana Home Dashboard",
-      "github": "mlamoure/indigo-grafana-dashboard"
+      "github": "mlamoure/indigo-grafana-dashboard",
+      "store_url": "https://www.indigodomo.com/pluginstore/167/",
+      "store_download": "https://api.github.com/repos/mlamoure/indigo-grafana-dashboard/zipball/v2.0.1"
     },
     "com.vtmikel.mcp_server": {
       "name": "MCP Server",
-      "github": "mlamoure/indigo-mcp-server"
+      "github": "mlamoure/indigo-mcp-server",
+      "store_url": "https://www.indigodomo.com/pluginstore/310/",
+      "store_download": "https://github.com/mlamoure/indigo-mcp-server/releases/download/v2026.0.1/MCP.Server.indigoPlugin.zip"
     },
     "com.vtmikel.securityspyimage": {
       "name": "Image downloader and SecuritySpy helper",
-      "github": "mlamoure/indigo-securityspy-image-downloader"
+      "github": "mlamoure/indigo-securityspy-image-downloader",
+      "store_url": "https://www.indigodomo.com/pluginstore/162/",
+      "store_download": "https://github.com/mlamoure/indigo-securityspy-image-downloader/releases/download/v2025.0.1/SecuritySpy.Image.Downloader.indigoPlugin.zip"
     },
     "com.weathersnoop.indigoplugin": {
       "name": "WeatherSnoop",
-      "github": "fluentweather/weathersnoop-indigoplugin"
+      "github": "fluentweather/weathersnoop-indigoplugin",
+      "store_url": "https://www.indigodomo.com/pluginstore/10/",
+      "store_download": "https://api.github.com/repos/FluentWeather/weathersnoop-indigoplugin/zipball/v3.2.0"
     },
     "com.webdeck.indigoplugin.bafcontrol": {
       "name": "BAF/Haiku",
-      "github": "webdeck/Indigo-BAF-Control"
+      "github": "webdeck/Indigo-BAF-Control",
+      "store_url": "https://www.indigodomo.com/pluginstore/321/",
+      "store_download": "https://github.com/webdeck/Indigo-BAF-Control/releases/download/2026.2.4/BAFControl.indigoPlugin.zip"
     },
     "com.whmoorejr.my-people": {
       "name": "My People",
-      "github": "whmoorejr/My-People"
+      "github": "whmoorejr/My-People",
+      "store_url": "https://www.indigodomo.com/pluginstore/244/",
+      "store_download": "https://github.com/whmoorejr/My-People/releases/download/v2022.0.1/MyPeople.indigoPlugin.zip"
     },
     "com.woodsmachine.indigoplugins.LightScenes": {
       "name": "Light Scenes",
-      "github": "rbdubz3/light-scenes-indigo"
+      "github": "rbdubz3/light-scenes-indigo",
+      "store_url": "https://www.indigodomo.com/pluginstore/251/",
+      "store_download": "https://github.com/rbdubz3/light-scenes-indigo/releases/download/2.0.1/LightScenes.indigoPlugin.zip"
     },
     "com.woodsmachine.indigoplugins.SmartSetpoints": {
       "name": "Smart Setpoints",
-      "github": "rbdubz3/smart-setpoints-indigo"
+      "github": "rbdubz3/smart-setpoints-indigo",
+      "store_url": "https://www.indigodomo.com/pluginstore/250/",
+      "store_download": "https://github.com/rbdubz3/smart-setpoints-indigo/releases/download/2.1.1/SmartSetpoints.indigoPlugin.zip"
     },
     "com.woodsmachine.indigoplugins.SylvaniaLightify": {
       "name": "Sylvania Lightify",
-      "github": "rbdubz3/sylvania-lightify-indigo"
+      "github": "rbdubz3/sylvania-lightify-indigo",
+      "store_url": "https://www.indigodomo.com/pluginstore/199/",
+      "store_download": "https://github.com/rbdubz3/sylvania-lightify-indigo/releases/download/2.0.1/SylvaniaLightify.indigoPlugin.zip"
     },
     "io.thechad.indigoplugin.pushover": {
       "name": "Pushover",
-      "github": "IndigoDomotics/indigo-pushover"
+      "github": "IndigoDomotics/indigo-pushover",
+      "store_url": "https://www.indigodomo.com/pluginstore/14/",
+      "store_download": "https://github.com/IndigoDomotics/indigo-pushover/releases/download/2022.0.2/Pushover.indigoPlugin.zip"
     },
     "io.thechad.indigoplugin.yamaharx": {
       "name": "Yamaha RX Receiver",
-      "github": "IndigoDomotics/indigo-yamaharx"
+      "github": "IndigoDomotics/indigo-yamaharx",
+      "store_url": "https://www.indigodomo.com/pluginstore/15/",
+      "store_download": "https://github.com/IndigoDomotics/indigo-yamaharx/releases/download/2022.0.3/YamahaRX.indigoPlugin.zip"
     },
     "net.dowles.doorbird": {
       "name": "DoorBird",
-      "github": "kwijibo007/DoorBird"
+      "github": "kwijibo007/DoorBird",
+      "store_url": "https://www.indigodomo.com/pluginstore/209/",
+      "store_download": "https://github.com/kwijibo007/DoorBird/releases/download/3.0.0/DoorBird.indigoPlugin.zip"
     },
     "net.dowles.monoprice6zoneamp": {
       "name": "Monoprice 6 Zone Amp",
-      "github": "kwijibo007/Monoprice-6-Zone-Amp"
+      "github": "kwijibo007/Monoprice-6-Zone-Amp",
+      "store_url": "https://www.indigodomo.com/pluginstore/55/",
+      "store_download": "https://github.com/kwijibo007/Monoprice-6-Zone-Amp/releases/download/2.0.0/Monoprice.6.Zone.Amp.indigoPlugin.zip"
     },
     "net.papamac.indigoplugin.virtualgaragedoor": {
       "name": "Virtual Garage Door",
-      "github": "papamac/VirtualGarageDoor"
+      "github": "papamac/VirtualGarageDoor",
+      "store_url": "https://www.indigodomo.com/pluginstore/267/",
+      "store_download": "https://github.com/papamac/VirtualGarageDoor/releases/download/v1.2.8/Virtual.Garage.Door.indigoPlugin.zip"
     },
     "net.zengers.weerlive": {
       "name": "WeerLive",
-      "github": "idurz/indigo-Weerlive"
+      "github": "idurz/indigo-Weerlive",
+      "store_url": "https://www.indigodomo.com/pluginstore/249/",
+      "store_download": "https://api.github.com/repos/idurz/Indigo-Weerlive/zipball/2.0.0"
     },
     "nl.rjdekok.indigoplugin.RFXCOM": {
       "name": "RFXCOM",
-      "github": "IndigoDomotics/rfxcom-plugin"
+      "github": "IndigoDomotics/rfxcom-plugin",
+      "store_url": "https://www.indigodomo.com/pluginstore/17/",
+      "store_download": "https://github.com/IndigoDomotics/rfxcom-plugin/releases/download/3.0.2/RFXCOM.indigoPlugin.zip"
     },
     "no.homeassistant.plugin": {
       "name": "Home Assistant Agent",
-      "github": "FlyingDiver/Indigo-HA-Agent"
+      "github": "FlyingDiver/Indigo-HA-Agent",
+      "store_url": "https://www.indigodomo.com/pluginstore/200/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-HA-Agent/releases/download/2025.1.7/HomeAssistantAgent.indigoPlugin.zip"
     },
     "org.cynic.indigo.behaviors": {
       "name": "Cynical Behaviors",
@@ -842,19 +1209,27 @@
     },
     "pro.sleepers.indigoplugin.8channel-relay": {
       "name": "8 Channel Network Relay",
-      "github": "IndigoDomotics/indigo-8channel-relay"
+      "github": "IndigoDomotics/indigo-8channel-relay",
+      "store_url": "https://www.indigodomo.com/pluginstore/196/",
+      "store_download": "https://github.com/IndigoDomotics/indigo-8channel-relay/releases/download/v2.0.1/8chRelay.indigoPlugin.zip"
     },
     "se.cobmedia.indigoplugin.virtualenergymeter": {
       "name": "Virtual Energy Meter",
-      "github": "IndigoDomotics/Indigo-VirtualEnergyMeter"
+      "github": "IndigoDomotics/Indigo-VirtualEnergyMeter",
+      "store_url": "https://www.indigodomo.com/pluginstore/194/",
+      "store_download": "https://github.com/IndigoDomotics/Indigo-VirtualEnergyMeter/releases/download/2023.1.0/Indigo-VirtualEnergyMeter.indigoPlugin.zip"
     },
     "se.furtenbach.indigo.plugin.beacon": {
       "name": "GeoFence",
-      "github": "FlyingDiver/Indigo-GeoFence"
+      "github": "FlyingDiver/Indigo-GeoFence",
+      "store_url": "https://www.indigodomo.com/pluginstore/121/",
+      "store_download": "https://github.com/FlyingDiver/Indigo-GeoFence/releases/download/2022.1.4/GeoFence.indigoPlugin.zip"
     },
     "uk.co.greensky.flux": {
       "name": "Flux LED",
-      "github": "IndigoDomotics/IndigoFluxLED"
+      "github": "IndigoDomotics/IndigoFluxLED",
+      "store_url": "https://www.indigodomo.com/pluginstore/163/",
+      "store_download": "https://github.com/IndigoDomotics/IndigoFluxLED/releases/download/2023.0.2/FluxLED.indigoPlugin.zip"
     }
   }
 }

--- a/skills/update-plugins/SKILL.md
+++ b/skills/update-plugins/SKILL.md
@@ -5,37 +5,51 @@ description: >-
   "update Indigo plugins", "bulk update plugins", "check which plugins are out
   of date", "upgrade plugins", "update all plugins", or similar bulk plugin
   maintenance tasks on an Indigo home automation server. Discovers installed
-  plugins via MCP, finds upgrade candidates from GitHub releases or the Indigo
-  plugin store, previews a diff, and applies upgrades with confirmation.
+  plugins via MCP, finds upgrade candidates from GitHub releases or the
+  bundled plugin source registry, previews a diff, and applies upgrades with
+  confirmation.
 ---
 
 # Indigo Plugin Bulk Updater
 
 Checks every installed Indigo plugin against its upstream source, reports which are out of date, and — with user confirmation — downloads and deploys upgrades. Interactive only.
 
-This skill is loaded by the `/indigo:update-plugins` command. The reference files under `references/` hold the detailed logic — this doc is the top-level workflow.
+Loaded by the `/indigo:update-plugins` command. The reference files under `references/` hold the detailed logic — this doc is the top-level workflow.
 
 ## Workflow
 
 ### Phase 1 — DISCOVER
 
-Call `mcp__indigo__list_plugins` (default `include_disabled=false`). For each returned entry, capture `id`, `name`, `version`, `enabled`, `path`.
+Call `mcp__indigo__list_plugins` with its default parameters (disabled plugins are excluded automatically). For each returned entry, capture `id`, `name`, `version` (note: this is `CFBundleVersion`, not `PluginVersion` — treat as advisory only), `enabled`, `path`.
 
-**Disabled plugins are intentionally not candidates.** `list_plugins` with its default parameter excludes them, which is what we want — restarting a disabled plugin via `restart_plugin` could re-enable it unexpectedly. If the user wants to update a disabled plugin, tell them to enable it in Indigo first, then re-run.
+**Disabled plugins are intentionally skipped.** `list_plugins` with its default parameter excludes them, which is what we want — restarting a disabled plugin via `restart_plugin` could re-enable it unexpectedly. If the user wants to update a disabled plugin, tell them to enable it in Indigo first, then re-run.
+
+**Installed version is `PluginVersion` from Info.plist, not the MCP `version` field.** The MCP `version` field usually returns `CFBundleVersion` which is rarely updated. For accurate version diffs, read `PluginVersion` directly:
+
+```bash
+/usr/libexec/PlistBuddy -c "Print :PluginVersion" "$PATH/Contents/Info.plist"
+```
+
+Where `$PATH` is the `path` from `list_plugins` (with mount-prefix handling — see `references/install-workflow.md`).
 
 ### Phase 2 — RESOLVE UPGRADE SOURCE
 
 Three sources checked in priority order. Full details in `references/discovery.md`. Short version:
 
-1. **Local `GithubInfo`** — read `<path>/Contents/Info.plist` for `GithubInfo.GithubUser` + `GithubInfo.GithubRepo`. If present → `gh api /repos/<user>/<repo>/releases/latest`.
-2. **Bundled registry** (`$CLAUDE_PLUGIN_ROOT/data/plugin-source-registry.json`) — a static `bundle_id → upstream` map that ships with this marketplace plugin. If the bundle ID is in the registry, use its `github` slug (preferred) or fetch its `store_url` (fallback for store-only plugins). **No runtime scraping for plugins in the registry** — it's a file read.
-3. **Store scraping fallback** — for plugins in neither Info.plist nor the registry. Rare. See `references/store-scraping.md`. Suggest the user open a PR adding an entry to the registry when this path triggers.
+1. **Local `GithubInfo`** — read `<path>/Contents/Info.plist` for `GithubInfo.GithubUser` + `GithubInfo.GithubRepo`. If present → `gh api /repos/<user>/<repo>/releases/latest`. **On 404 or any other error, fall through to Source 2** — local metadata is sometimes stale.
+2. **Bundled registry** (`$CLAUDE_PLUGIN_ROOT/data/plugin-source-registry.json`, with optional live overlay from `raw.githubusercontent.com`) — a `bundle_id → {name, github?, store_url?, store_download?}` map. Resolution:
+   - If entry has `github` → query GitHub releases. If the release has no `.indigoPlugin.zip` asset, try the GitHub zipball (`api.github.com/.../zipball/<tag>`). If that also fails, fall back to `store_download` if present.
+   - If entry has only `store_url` → fetch the detail page at runtime to extract current version and download URL.
+   - No runtime scraping for plugins that resolve fully through GitHub.
+3. **Store scraping fallback** — for plugins in neither Info.plist nor registry. Rare; suggest a PR adding the plugin to the registry.
+
+If none resolve → mark unresolved and continue.
 
 Parallelise. See `references/discovery.md` for concurrency notes.
 
 ### Phase 3 — DIFF
 
-For each plugin with a resolved upstream, compare installed version to latest. Strip a leading `v`. Prefer `python3 -c 'from packaging.version import parse as p; ...'` if Python is available in the runtime; otherwise split on `.` and compare numeric segments, falling back to string compare if a segment isn't an integer. `2026.4.1`, `1.0.3`, `v1.0-beta` should all work.
+For each plugin with a resolved upstream, compare installed version to latest. Strip leading `v`. Prefer `python3 -c 'from packaging.version import parse as p; ...'` if Python is available in the runtime; otherwise split on `.` and compare numeric segments, falling back to string compare if a segment isn't an integer. `2026.4.1`, `1.0.3`, `v1.0-beta` should all work.
 
 Produce a grouped report:
 
@@ -71,20 +85,24 @@ Anything ambiguous → ask again.
 
 Follow `references/install-workflow.md` per plugin, one at a time. That file is the authoritative sequence; do not reinvent it here.
 
+**Special case — MCP Server self-upgrade**: if the batch includes `com.vtmikel.mcp_server` (the plugin this skill uses to talk to Indigo), handle it specially — restarting it kills the skill's own connection. See the "Hard limitations" section in `install-workflow.md`. Recommended: skip with a clear manual-instruction message.
+
 ### Phase 6 — SUMMARY
 
-Print three sections: **Upgraded** (name, old → new version), **Failed** (name, reason, one-line manual recovery hint), **Unresolved** (name, why no source was found).
+Print three sections: **Upgraded** (name, old → new version), **Failed** (name, reason, one-line manual recovery hint), **Unresolved** (name, why no source was found). Also list any **Deferred** entries (e.g. MCP Server) separately with the exact manual steps needed.
 
 ## Safety Rules
 
-The rules below are enforced by the phased instructions above and by the detailed sequence in `references/install-workflow.md`. They are listed here so a reader can audit them at a glance.
+Enforced by phase ordering and by the detailed sequence in `references/install-workflow.md`. Listed here for at-a-glance audit.
 
 - **Updates only.** Never install a plugin that isn't already returned by `mcp__indigo__list_plugins`. First installs go through Indigo's UI.
 - **Verify bundle ID before rsync.** Step 4 of the install workflow aborts the upgrade if the staged bundle's `CFBundleIdentifier` doesn't match the installed plugin.
-- **Deploy path comes from MCP.** Never hardcode `/Library/Application Support/...`. Read it from the `path` field returned by `list_plugins` / `get_plugin_by_id`.
-- **Interactive only.** No cron, no hooks, no silent apply. The user always sees the report and types confirmation.
-- **One plugin at a time.** Failures stay isolated; the Indigo server is never left mid-restart on a known-good upgrade.
+- **Deploy path comes from MCP.** Never hardcode `/Library/Application Support/...`. Read from the `path` field returned by `list_plugins` / `get_plugin_by_id`. For cross-mount setups (skill running on a different Mac than the Indigo server), detect and apply a mount prefix.
+- **Interactive only.** No cron, no hooks, no silent apply.
+- **One plugin at a time.** Failures stay isolated.
 - **Disabled plugins are skipped.** See Phase 1.
+- **MCP Server never self-restarts via this skill.** Dedicated manual path.
+- **Stop before rsync, start after.** For plugins with bundled native extensions, running-plugin file locks can break `rsync --delete`. The workflow restarts before and after the rsync for that reason.
 
 ## Related Skills
 

--- a/skills/update-plugins/SKILL.md
+++ b/skills/update-plugins/SKILL.md
@@ -27,10 +27,11 @@ Call `mcp__indigo__list_plugins` with its default parameters (disabled plugins a
 **Installed version is `PluginVersion` from Info.plist, not the MCP `version` field.** The MCP `version` field usually returns `CFBundleVersion` which is rarely updated. For accurate version diffs, read `PluginVersion` directly:
 
 ```bash
-/usr/libexec/PlistBuddy -c "Print :PluginVersion" "$PATH/Contents/Info.plist"
+PLUGIN_PATH="..."  # `path` from mcp__indigo__list_plugins (with mount-prefix handling)
+/usr/libexec/PlistBuddy -c "Print :PluginVersion" "$PLUGIN_PATH/Contents/Info.plist"
 ```
 
-Where `$PATH` is the `path` from `list_plugins` (with mount-prefix handling — see `references/install-workflow.md`).
+See `references/install-workflow.md` "Deploy path portability" for the mount-prefix handling.
 
 ### Phase 2 — RESOLVE UPGRADE SOURCE
 
@@ -102,7 +103,7 @@ Enforced by phase ordering and by the detailed sequence in `references/install-w
 - **One plugin at a time.** Failures stay isolated.
 - **Disabled plugins are skipped.** See Phase 1.
 - **MCP Server never self-restarts via this skill.** Dedicated manual path.
-- **Stop before rsync, start after.** For plugins with bundled native extensions, running-plugin file locks can break `rsync --delete`. The workflow restarts before and after the rsync for that reason.
+- **File-lock aware rsync.** Plugins with bundled native extensions can hold file locks that break `rsync --delete`. The workflow retries without `--delete` as a soft fallback when it hits `unlinkat: Directory not empty`. Cleaner approach (MCP `stop_plugin` tool) is filed as an upstream ask.
 
 ## Related Skills
 

--- a/skills/update-plugins/references/discovery.md
+++ b/skills/update-plugins/references/discovery.md
@@ -20,11 +20,11 @@ Example:
 
 ### Reading GithubInfo
 
-The bundle path comes from `mcp__indigo__list_plugins` (the `path` field). Use the absolute `PlistBuddy` path so this works on any macOS without relying on `$PATH`:
+The bundle path comes from `mcp__indigo__list_plugins` (the `path` field, captured into `$PLUGIN_PATH`). Use the absolute `PlistBuddy` binary path so this works on any macOS without relying on the system `$PATH` variable:
 
 ```bash
-/usr/libexec/PlistBuddy -c "Print :GithubInfo:GithubUser" "$PATH/Contents/Info.plist" 2>/dev/null
-/usr/libexec/PlistBuddy -c "Print :GithubInfo:GithubRepo" "$PATH/Contents/Info.plist" 2>/dev/null
+/usr/libexec/PlistBuddy -c "Print :GithubInfo:GithubUser" "$PLUGIN_PATH/Contents/Info.plist" 2>/dev/null
+/usr/libexec/PlistBuddy -c "Print :GithubInfo:GithubRepo" "$PLUGIN_PATH/Contents/Info.plist" 2>/dev/null
 ```
 
 Non-zero exit → no GitHub source declared → fall through to Source 2.

--- a/skills/update-plugins/references/discovery.md
+++ b/skills/update-plugins/references/discovery.md
@@ -1,10 +1,10 @@
 # Upgrade Source Discovery
 
-How to find the upstream source for an installed Indigo plugin. Three sources, checked in priority order; fall through on miss.
+How to find the upstream source for an installed Indigo plugin. Sources are checked in priority order; on miss, fall through.
 
-## Source 1: `Info.plist` `GithubInfo` (preferred)
+## Source 1: `Info.plist` `GithubInfo` (fastest when it works)
 
-Plugins that ship via GitHub often embed a `GithubInfo` dict in `Contents/Info.plist`. When present, it gives us the repo coordinates with zero guessing and works for every install of that plugin without needing any shared data.
+Plugins that ship via GitHub often embed a `GithubInfo` dict in `Contents/Info.plist`. When present and correct, it gives us the repo coordinates per-install with zero shared data needed.
 
 Example:
 
@@ -35,43 +35,57 @@ Non-zero exit → no GitHub source declared → fall through to Source 2.
 gh api /repos/$USER/$REPO/releases/latest
 ```
 
-Capture:
+Capture from the JSON response:
 - `tag_name` — release tag (strip leading `v` before version compare)
 - `html_url` — release page, used as release notes link
-- `assets[*]` — find the entry whose `name` ends in `.indigoPlugin.zip`; record its `browser_download_url`. If no such asset exists, mark the plugin as unresolved (upstream exists but doesn't publish a downloadable bundle)
+- `assets[*]` — find the entry whose `name` ends in `.indigoPlugin.zip`; record its `browser_download_url`. **If no such asset exists, do not mark the plugin unresolved yet** — fall back to the zipball URL `https://api.github.com/repos/$USER/$REPO/zipball/$TAG`, which downloads the repo source snapshot at that tag. Some authors ship plugins as a source-only release where the `.indigoPlugin/` bundle is embedded in the repo tree; the install workflow knows how to handle that layout (see `install-workflow.md` step 3).
 
-`gh api` returns 404 if the repo has no releases yet, or if it's private and the user's token lacks access. Both cases → mark the plugin as unresolved with a short reason string so the user knows why.
+### Fall-through on gh-api failure
+
+**Important**: if `gh api` returns 404 or any other error for this `GithubInfo`, do not mark the plugin unresolved. Instead fall through to Source 2 (the bundled registry). The local `GithubInfo` is sometimes stale or wrong — a plugin author may have moved the repo, typo'd the slug, or published a new release path. The registry is curated and often has a working slug for plugins whose local metadata is bad.
+
+Common stale-local cases observed in the wild:
+- `simons-plugins/UKTrains` (local) vs `simons-plugins/indigo-UKTrains` (registry)
+- `FlyingDiver/Indigo-Harmony` (local) vs the actual published repo name in the registry
+- `Ghawken/iMessagePlugin` (local) 404s; registry may have a different slug
+
+### Private repos
+
+If `gh api` returns 404 *and* the registry also has no entry, the repo may be private and the user's token lacks access. Report the plugin as unresolved with a "private repository or missing GithubInfo" hint.
 
 ## Source 2: Bundled plugin source registry
 
-`data/plugin-source-registry.json` at the root of this marketplace plugin is a pre-populated map of `bundle_id → upstream`. Ships as static data so there is **zero runtime scraping** for plugins in the registry — it's a file read, not a network request. Fresh registry updates arrive via `/plugin marketplace update`, the same mechanism users already use to get new skill code.
+`$CLAUDE_PLUGIN_ROOT/data/plugin-source-registry.json` — a pre-populated map of `bundle_id → upstream` that ships with this marketplace plugin. Zero runtime scraping for plugins in the registry — it's a file read.
 
-### Registry schema
+### Registry schema (v2)
 
 ```json
 {
   "updated_at": "2026-04-15",
-  "note": "...",
-  "source": "...",
+  "schema_version": 2,
   "plugins": {
     "<bundle_id>": {
       "name": "Human-readable name",
-      "github": "user/repo"
-    },
-    "<other_bundle_id>": {
-      "name": "Human-readable name",
+      "github": "user/repo",
       "store_url": "https://www.indigodomo.com/pluginstore/N/",
-      "store_download": "https://downloads.indigodomo.com/pluginstore/.../plugin.indigoPlugin.zip"
+      "store_download": "https://downloads.indigodomo.com/.../plugin.indigoPlugin.zip"
     }
   }
 }
 ```
 
-Entries come in two shapes:
+**Field semantics** (each optional except `name`):
 
-**GitHub-backed** — has a `github` field (`user/repo` slug). Resolution is identical to Source 1: query `gh api /repos/<github>/releases/latest` and use the tag + asset URL. This is the overwhelming majority of entries (~90% after the initial seed).
+- `name` — display name. Always present.
+- `github` — `user/repo` slug. If present, prefer GitHub releases for version tracking.
+- `store_url` — Indigo store detail page URL. Used as a release-notes link and as a runtime fetch target for store-only plugins (see below).
+- `store_download` — direct download URL from the store page. Used as a **download fallback** when the GitHub release has no `.indigoPlugin.zip` asset AND the zipball fallback doesn't work. Always preserved when scraping, even for GitHub-backed entries, so there's something to fall back to.
 
-**Store-only** — has `store_url` and optionally `store_download`. The plugin is published via Indigo's store with no GitHub mirror, so we still need a lightweight runtime fetch to get the latest version. Fetch the `store_url` detail page, parse it per `store-scraping.md`, and extract the latest version and download URL. This is one HTTP GET per store-only plugin per run (no listing enumeration, no cache-build sweep).
+Entries come in three shapes in practice:
+
+1. **GitHub-backed with fallback** (most common, ~187/208): `github` + `store_download`. Version tracking via `gh api releases/latest`, download asset fallback via `store_download` if the release doesn't publish a `.indigoPlugin.zip`.
+2. **Store-only** (~21/208): `store_url` + `store_download` only, no `github`. Version tracking requires fetching `store_url` at runtime and parsing the detail page. Download via `store_download`.
+3. **GitHub-only** (rare): `github` with no store fields. Fine — upstream never got indexed on the store, or the scrape missed it.
 
 ### Loading the registry
 
@@ -79,7 +93,7 @@ Entries come in two shapes:
 REGISTRY="$CLAUDE_PLUGIN_ROOT/data/plugin-source-registry.json"
 ```
 
-`$CLAUDE_PLUGIN_ROOT` is set by Claude Code to the root of this marketplace plugin. Read the JSON, look up the installed bundle ID under `.plugins`:
+`$CLAUDE_PLUGIN_ROOT` is set by Claude Code to the root of this marketplace plugin. Read the JSON, look up by bundle ID:
 
 ```bash
 jq -e ".plugins[\"$BUNDLE_ID\"]" "$REGISTRY"
@@ -87,31 +101,41 @@ jq -e ".plugins[\"$BUNDLE_ID\"]" "$REGISTRY"
 
 Non-zero exit → not in the registry → fall through to Source 3.
 
+### Live overlay (optional, short-circuits release cycle)
+
+The bundled registry updates only when a new version of `indigo-claude-plugin` is pulled via `/plugin marketplace update`. To let registry contributors see their additions take effect immediately without waiting for a release, the skill also looks for a live overlay at `$HOME/.claude/indigo-plugin-source-registry-live.json`.
+
+Resolution order:
+
+1. If the live overlay exists AND is younger than 6 hours, use it.
+2. If the live overlay exists AND is older than 6 hours, OR doesn't exist, fetch `https://raw.githubusercontent.com/simons-plugins/indigo-claude-plugin/main/data/plugin-source-registry.json`, validate it parses as JSON with the expected schema (has `plugins` key with a dict value), write it to the live overlay path atomically, use it.
+3. If the fetch fails (offline, GitHub down, rate-limited), fall back to the bundled `$CLAUDE_PLUGIN_ROOT/data/plugin-source-registry.json`.
+
+`/indigo:update-plugins refresh` as a user-facing refresh: delete the live overlay file and re-fetch.
+
+This means: contributors PR a new entry → merge to `main` → live within 6 hours for everyone running the skill, no release needed.
+
 ### Contributing to the registry
 
-Users who discover a plugin not in the registry — or a GitHub URL the registry doesn't know about — are expected to open a PR against `simons-plugins/indigo-claude-plugin` adding or updating an entry. The registry is a flat JSON file, easy to edit, and the next marketplace update pushes the change to everyone.
-
-Keep entries minimal. No versions, no dates, no dependency info — the whole file is just a routing table from bundle ID to upstream.
+Users who discover a plugin not in the registry — or notice a stale `github` slug — open a PR against `simons-plugins/indigo-claude-plugin` adding or updating an entry in `data/plugin-source-registry.json`. CI should skip the version-bump check for PRs whose diff is entirely under `data/`, so registry-only PRs don't bump the plugin version.
 
 ## Source 3: Store scraping fallback (rare)
 
-For installed plugins that are in neither the local Info.plist nor the bundled registry. See `store-scraping.md`. This path is now expected to be unusual — the bundled registry covers the common case, so store scraping only kicks in when a user has installed a plugin the registry author hasn't seen yet.
-
-When this path triggers, suggest to the user that they open a PR to add the plugin to the bundled registry so future users don't need to re-scrape.
+For installed plugins that are in neither the local Info.plist nor the registry. See `store-scraping.md`. Suggest the user open a PR adding the plugin to the registry when this path triggers.
 
 ## Unresolved
 
-Plugins that didn't resolve through any of the three sources. Informational, not an error. Common reasons:
+Plugins that didn't resolve through any source. Informational, not an error. Common reasons:
 
+- Built-in Indigo plugins (Airfoil Pro, Alexa, Email+, Virtual Devices, SQL Logger, Timers and Pesters, Global Property Manager) — ship with Indigo itself, not from GitHub or a public store entry
 - Sideloaded from a private `.indigoPlugin.zip`
-- Lives on GitHub but neither the Info.plist nor the registry knows the repo
+- GitHub-hosted but neither Info.plist nor registry knows the repo
 - Author distributes via their own website
-- Plugin was never fully set up
 
-Manual remediation hint: "check the plugin's documentation or contact the author for update instructions, then consider adding an entry to `data/plugin-source-registry.json`."
+Manual remediation hint: "check the plugin's documentation, or add an entry to `data/plugin-source-registry.json` if you know the source."
 
 ## Parallelisation
 
-Phase 2 is per-plugin independent. Run it concurrently with background bash — `gh api` calls, `PlistBuddy` reads, and registry lookups are all independent. Cap concurrency at ~8 to be polite to GitHub and the user's network. For small plugin counts (<10) serial is fine.
+Phase 2 is per-plugin independent. Run concurrently with background bash. `gh api` calls, `PlistBuddy` reads, and registry lookups are all independent. Cap concurrency at ~8. For small plugin counts (<10) serial is fine.
 
-Don't persist per-plugin Phase 2 results across runs — GitHub releases change and a stale per-plugin cache produces wrong diffs. The registry is the only persistent data; live version checks against GitHub or store are always fresh.
+Don't persist per-plugin Phase 2 results across runs — GitHub releases change and a stale per-plugin cache produces wrong diffs. The registry (bundled + live overlay) is the only persistent data; live version checks against GitHub or store are always fresh.

--- a/skills/update-plugins/references/install-workflow.md
+++ b/skills/update-plugins/references/install-workflow.md
@@ -2,17 +2,49 @@
 
 The mechanical sequence for applying a single plugin upgrade. Safety-critical — writes to the running Indigo install.
 
-First installs must go through Indigo's UI (double-click registers the bundle with the server). This workflow only handles updates to already-registered bundles: rsync over the existing `Contents/` and the Indigo server picks up the new code on restart.
+First installs go through Indigo's UI (double-click registers the bundle). This workflow only handles updates to already-registered bundles: stop the plugin, rsync over the existing `Contents/`, start it again, verify. The Indigo server picks up the new code on restart.
 
 ## Prerequisites
 
 Before calling this workflow:
-- `mcp__indigo__list_plugins` has returned an entry for the target bundle ID (updates only)
-- Phase 2 resolved an upstream source (GitHub or store) with a `download_url`
-- Phase 4 confirmed installed version is strictly less than upstream
-- Phase 5 — user explicitly confirmed this plugin or `all`
+- `mcp__indigo__list_plugins` returned an entry for the target bundle ID
+- Phase 2 resolved an upstream source (GitHub release, zipball fallback, or store download)
+- Phase 3 confirmed installed version is strictly less than upstream
+- Phase 4 — user explicitly confirmed this plugin or `all`
 
-If any of those aren't true, do not run.
+If any aren't true, do not run.
+
+## Hard limitations (must check before applying)
+
+### Do not self-upgrade the MCP server
+
+If the bundle ID being upgraded is `com.vtmikel.mcp_server` (the Indigo MCP Server plugin), **do not call `mcp__indigo__restart_plugin`** as part of the workflow. Restarting the MCP Server kills the connection this skill uses to talk to Indigo, and subsequent MCP calls fail mid-batch.
+
+Two options:
+1. **Skip entirely** — report "MCP Server upgrade requires manual deploy — this skill uses the MCP connection and can't restart itself. Disable the plugin in Indigo's UI, rsync the new bundle, re-enable."
+2. **Deploy then defer** — do steps 1–6 (download → stage → verify → rsync), skip step 7 (restart), and tell the user the exact `mcp__indigo__restart_plugin(plugin_id="com.vtmikel.mcp_server")` call they need to run from a fresh session after this one exits.
+
+Option 1 is safer. Option 2 requires warning the user clearly that the MCP state on disk is new but the running process is still old until they restart.
+
+### Deploy path portability
+
+The destination for rsync comes from the `path` field returned by `mcp__indigo__list_plugins` / `mcp__indigo__get_plugin_by_id`. **Do not hardcode** `/Library/Application Support/...`.
+
+**Cross-machine mount handling**: if the user is running this skill on a different Mac than the Indigo server (e.g. Indigo on `jarvis.local` mounted as `/Volumes/<VolumeName>/`), the MCP-reported absolute path won't exist directly. Detect this:
+
+```bash
+if [ ! -d "$MCP_REPORTED_PATH/Contents" ]; then
+    # Try common mount points
+    for prefix in "/Volumes/Macintosh HD-1" "/Volumes/Macintosh HD"; do
+        if [ -d "${prefix}${MCP_REPORTED_PATH}/Contents" ]; then
+            DEPLOY_PATH="${prefix}${MCP_REPORTED_PATH}"
+            break
+        fi
+    done
+fi
+```
+
+If no candidate resolves, fail with a clear message: "Indigo server path `<path>` not directly accessible. Is the Indigo server Mac's filesystem mounted?" Ask the user to surface the prefix as a one-off setting.
 
 ## Step-by-step sequence
 
@@ -25,11 +57,11 @@ STAGE_DIR="$TMPDIR/stage"
 mkdir -p "$DOWNLOAD_DIR" "$STAGE_DIR"
 ```
 
-Track `$TMPDIR` for cleanup in step 9.
+Track `$TMPDIR` for cleanup in step 10.
 
 ### 2. Download the bundle
 
-**GitHub source:**
+**GitHub release asset (preferred path):**
 
 ```bash
 gh release download "$TAG" \
@@ -38,15 +70,26 @@ gh release download "$TAG" \
     --dir "$DOWNLOAD_DIR"
 ```
 
-Pass the tag explicitly (don't omit it) so the release can't be updated mid-run under our feet. Note: if the repo has no published releases, `gh api` in Phase 2 returns 404; the plugin should already have been classified as unresolved before we got here.
+Pass the tag explicitly so the release can't be retagged mid-run.
 
-**Store source:**
+**GitHub zipball fallback** — when the release has no `.indigoPlugin.zip` asset (some authors publish source-only releases with the plugin bundle embedded in the repo tree):
 
 ```bash
-curl -L -f -o "$DOWNLOAD_DIR/bundle.zip" "$DOWNLOAD_URL"
+curl -L -f -o "$DOWNLOAD_DIR/bundle.zip" \
+    "https://api.github.com/repos/$USER/$REPO/zipball/$TAG"
 ```
 
-`-f` → exit non-zero on HTTP errors (401/403/404/5xx). `-L` → follow redirects (GitHub release assets redirect through a CDN).
+The resulting zip unzips to a wrapper directory like `<user>-<repo>-<sha>/` with the `.indigoPlugin/` inside it. Step 3 handles both layouts.
+
+**Store download fallback** — when the GitHub release is unusable (no asset, no zipball, 404, etc.) but the registry entry has a `store_download` field:
+
+```bash
+curl -L -f -o "$DOWNLOAD_DIR/bundle.zip" "$STORE_DOWNLOAD"
+```
+
+`-f` exits non-zero on HTTP errors. `-L` follows redirects.
+
+**Unresolvable** — if none of the three download paths work, fail the upgrade for this plugin with: "no downloadable plugin asset found via GitHub release, zipball, or store download — contact the plugin author." Do not proceed to rsync.
 
 Assert exactly one `.zip` landed in `$DOWNLOAD_DIR`:
 
@@ -60,11 +103,14 @@ ZIP_PATH=$(find "$DOWNLOAD_DIR" -maxdepth 1 -name '*.zip' | head -1)
 
 ```bash
 unzip -q -o "$ZIP_PATH" -d "$STAGE_DIR"
-STAGED_BUNDLE=$(find "$STAGE_DIR" -maxdepth 1 -name '*.indigoPlugin' -type d | head -1)
+# Handle both flat bundles and zipball-wrapped bundles
+STAGED_BUNDLE=$(find "$STAGE_DIR" -maxdepth 3 -name '*.indigoPlugin' -type d | head -1)
 [ -n "$STAGED_BUNDLE" ] || { echo "no .indigoPlugin bundle in zip"; exit 1; }
 ```
 
-If no bundle is found at the top level of `$STAGE_DIR`, fail this plugin — treat as a corrupted or wrong-artifact download.
+**Note on `-maxdepth 3`**: release-asset zips have the bundle at the top level (`.indigoPlugin/` directly). Zipballs wrap it one level deep (`<user>-<repo>-<sha>/.indigoPlugin/`). Some weird zips go deeper. Three levels catches all observed layouts without walking the whole tree.
+
+If no bundle is found, fail this plugin — treat as corrupted or wrong-artifact download.
 
 ### 4. Verify bundle identifier (critical safety check)
 
@@ -72,14 +118,14 @@ If no bundle is found at the top level of `$STAGE_DIR`, fail this plugin — tre
 STAGED_BUNDLE_ID=$(/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$STAGED_BUNDLE/Contents/Info.plist")
 ```
 
-Assert `STAGED_BUNDLE_ID == $EXPECTED_BUNDLE_ID` (from `mcp__indigo__list_plugins`). If it doesn't match:
+Assert `STAGED_BUNDLE_ID == $EXPECTED_BUNDLE_ID` (from `mcp__indigo__list_plugins`). On mismatch:
 
 - Log the mismatch with both IDs
 - Do **not** rsync
 - Mark this plugin's upgrade as failed
 - Continue to the next plugin
 
-This check guards against wrong-bundle substitution — a download URL pointing at a different plugin than expected (cache typo, store misconfiguration, upstream compromise). Without it, rsync would silently replace a totally unrelated plugin.
+This check prevents wrong-bundle substitution — a download URL pointing at a different plugin than expected (cache typo, store misconfiguration, upstream compromise). Without it, rsync would silently replace an unrelated plugin.
 
 ### 5. Verify version (soft check)
 
@@ -87,39 +133,53 @@ This check guards against wrong-bundle substitution — a download URL pointing 
 STAGED_VERSION=$(/usr/libexec/PlistBuddy -c "Print :PluginVersion" "$STAGED_BUNDLE/Contents/Info.plist")
 ```
 
-Compare `STAGED_VERSION` to what the upstream source advertised. Mismatch → log a warning and continue (upstream may have published a new release between check and apply — not a hard fail). The final installed version shows up in Phase 7.
+Compare to the advertised upstream version. Mismatch → log a warning and continue. Final installed version shows up in Phase 6.
 
-### 6. Deploy via rsync
+### 6. Stop the plugin before rsync
 
-Destination is the `path` field from `mcp__indigo__list_plugins` or `mcp__indigo__get_plugin_by_id`. **Do not hardcode** — always read from MCP. This is what makes the skill portable across different Indigo installs.
-
-```bash
-rsync -av --delete "$STAGED_BUNDLE/Contents/" "$INSTALLED_PATH/Contents/"
-```
-
-Trailing slashes matter: `.../Contents/` → `.../Contents/` copies contents rather than nesting. `--delete` removes files present in the old bundle but not the new one, so removed-upstream files don't linger.
-
-If rsync fails (permission denied, disk full, target not found), fail this plugin and continue. **Do not sudo.** If the user running this skill doesn't own the Plugins folder, the Indigo server is running as a different user and the permissions need to be resolved manually.
-
-### 7. Restart the plugin
+**Critical ordering**: stop the plugin first, then rsync, then start it again. The old order (rsync → restart) fails for plugins with bundled native extensions (e.g. `Packages/pyarrow`) where running-plugin file locks block `rsync --delete`, leaving `Contents/` in a mixed state: new `Info.plist` but old `Packages/`.
 
 ```text
 mcp__indigo__restart_plugin(plugin_id=$BUNDLE_ID)
 ```
 
-### 8. Verify startup
+Wait: there's no `stop_plugin` MCP tool. The workaround is to issue `restart_plugin` *before* rsync — Indigo stops the process, starts a new one from disk, which at that moment still has the old files, then we immediately rsync the new files over the (now-not-locked) `Packages/` directory. On the next restart in step 7, Indigo picks up the new version.
+
+The cleaner fix would be an MCP `stop_plugin` tool — worth filing upstream against `mlamoure/indigo-mcp-server`. Until then, two restarts (before + after) is the correct sequence.
+
+### 7. Deploy via rsync
+
+```bash
+rsync -a --delete "$STAGED_BUNDLE/Contents/" "$DEPLOY_PATH/Contents/"
+```
+
+Trailing slashes matter: `.../Contents/` → `.../Contents/` copies contents rather than nesting. `--delete` removes files present in the old bundle but not the new one.
+
+If rsync fails (permission denied, disk full, target not found), fail this plugin and continue. Do **not** sudo.
+
+**If `--delete` still fails** with "Directory not empty" despite the pre-stop in step 6 (very bundled native extensions may re-grab locks mid-rsync), retry once without `--delete` as a soft fallback — the new files land on top, leftovers from the old version linger in unused directories, log a warning.
+
+### 8. Restart the plugin
+
+```text
+mcp__indigo__restart_plugin(plugin_id=$BUNDLE_ID)
+```
+
+**Except** when `$BUNDLE_ID == com.vtmikel.mcp_server` — see the hard limitation section above. Defer this call and tell the user to run it from a fresh session.
+
+### 9. Verify startup
 
 Two checks. The **version check is the primary success signal**; the log check is a secondary sanity pass because the exact `TypeVal` severity mapping isn't well-documented and shouldn't be the sole oracle.
 
 **Version check (primary):**
 
-```text
-mcp__indigo__get_plugin_by_id(plugin_id=$BUNDLE_ID)
+Poll `mcp__indigo__get_plugin_by_id` but note it may return `CFBundleVersion` (e.g. `2.0.0`) rather than `PluginVersion` (e.g. `2026.4.1`). If in doubt, read the live `$DEPLOY_PATH/Contents/Info.plist` `PluginVersion` field via `/usr/libexec/PlistBuddy`:
+
+```bash
+/usr/libexec/PlistBuddy -c "Print :PluginVersion" "$DEPLOY_PATH/Contents/Info.plist"
 ```
 
-Poll until the returned `version` field matches the new upstream version (with a ~15s timeout). Be lenient: `get_plugin_by_id` can return `CFBundleVersion` (e.g. `2.0.0`) rather than `PluginVersion` depending on the plugin. If there's ambiguity, read `$INSTALLED_PATH/Contents/Info.plist` directly via `/usr/libexec/PlistBuddy -c "Print :PluginVersion"` and compare.
-
-If the polled version never matches within the timeout → treat as a failed upgrade.
+Compare to the expected new version. Mismatch after 15s → treat as failed.
 
 **Log check (secondary):**
 
@@ -129,14 +189,14 @@ mcp__indigo__query_event_log(line_count=50)
 
 Each entry has `Message`, `TypeVal`, `TypeStr`, `TimeStamp`. Scan for:
 
-- Success marker: a recent `Application`-type entry (`TypeStr="Application"`) with `Message` starting `"Started plugin \"<name> <version>\""` that references this bundle's display name
-- Potential failure: any entry whose `TypeStr` starts with `"Web Server Warning"` or contains the word `"Error"`, or any entry whose `TypeStr` matches the plugin's display name and whose message contains `error`/`exception`/`traceback`
+- Success marker: a recent `Application`-type entry (`TypeStr == "Application"`) with `Message` starting `"Started plugin \"<name> <version>\""` referencing this bundle's display name and the new version
+- Potential failure: any entry whose `TypeStr` matches the plugin's display name and whose message contains `error`, `exception`, or `traceback`
 
-Treat missing success marker as inconclusive, not failed, if the version check already passed. Treat a version-check failure as a failed upgrade regardless of what the log says.
+Treat missing success marker as inconclusive, not failed, if the version check already passed. Treat a version-check failure as failed regardless.
 
-If the upgrade rsync'd cleanly but the new code throws errors after restart, report the failure. **Do not roll back** — rollback is out of scope for v1; let the user decide whether to revert.
+**No rollback.** If the upgrade rsync'd cleanly but the new code throws errors after restart, report the failure and let the user decide whether to revert manually.
 
-### 9. Cleanup
+### 10. Cleanup
 
 ```bash
 rm -rf "$TMPDIR"
@@ -148,9 +208,12 @@ Always run this, even on failure.
 
 | Failure mode | Where | Recovery |
 |--------------|-------|----------|
-| 404 downloading asset | Step 2 | Upstream release deleted or URL changed; refresh store cache or recheck GitHub releases |
-| Zip has no `.indigoPlugin` directory | Step 3 | Corrupted or wrong-artifact download; fail this plugin |
-| Bundle identifier mismatch | Step 4 | Cached metadata wrong; don't rsync, fail this plugin |
-| rsync permission denied | Step 6 | Indigo filesystem perms problem — user must resolve manually; continue with other plugins |
-| Plugin restart hangs | Step 7 | MCP `restart_plugin` has its own timeout; if it never returns, report "restart uncertain" and let the user check Indigo's UI |
-| Log shows errors after restart | Step 8 | Upgrade is applied but new code misbehaves; mark failed, suggest checking release notes for config migration steps |
+| 404 downloading asset | Step 2 | Try zipball fallback, then store_download fallback, then fail |
+| Zipball has no `.indigoPlugin` at any depth | Step 3 | Corrupted or source-only repo; fail this plugin |
+| Bundle identifier mismatch | Step 4 | Cached metadata wrong; don't rsync, fail |
+| `rsync --delete` "Directory not empty" | Step 7 | Stop was ineffective for this plugin — retry without `--delete` as a soft fallback, leave cleanup to the user |
+| rsync permission denied | Step 7 | Indigo filesystem perms — user resolves manually; continue with other plugins |
+| Plugin restart hangs | Step 8 | MCP `restart_plugin` has its own timeout; if it never returns, report "restart uncertain" |
+| Bundle ID is `com.vtmikel.mcp_server` | Step 8 | Do not call restart; tell user to restart from a fresh session |
+| Log shows errors after restart | Step 9 | Upgrade applied but new code misbehaves; mark failed, suggest release notes |
+| Deploy path not accessible | Prereq | Cross-mount detection failed; ask user for the mount prefix |

--- a/skills/update-plugins/references/install-workflow.md
+++ b/skills/update-plugins/references/install-workflow.md
@@ -135,19 +135,7 @@ STAGED_VERSION=$(/usr/libexec/PlistBuddy -c "Print :PluginVersion" "$STAGED_BUND
 
 Compare to the advertised upstream version. Mismatch → log a warning and continue. Final installed version shows up in Phase 6.
 
-### 6. Stop the plugin before rsync
-
-**Critical ordering**: stop the plugin first, then rsync, then start it again. The old order (rsync → restart) fails for plugins with bundled native extensions (e.g. `Packages/pyarrow`) where running-plugin file locks block `rsync --delete`, leaving `Contents/` in a mixed state: new `Info.plist` but old `Packages/`.
-
-```text
-mcp__indigo__restart_plugin(plugin_id=$BUNDLE_ID)
-```
-
-Wait: there's no `stop_plugin` MCP tool. The workaround is to issue `restart_plugin` *before* rsync — Indigo stops the process, starts a new one from disk, which at that moment still has the old files, then we immediately rsync the new files over the (now-not-locked) `Packages/` directory. On the next restart in step 7, Indigo picks up the new version.
-
-The cleaner fix would be an MCP `stop_plugin` tool — worth filing upstream against `mlamoure/indigo-mcp-server`. Until then, two restarts (before + after) is the correct sequence.
-
-### 7. Deploy via rsync
+### 6. Deploy via rsync
 
 ```bash
 rsync -a --delete "$STAGED_BUNDLE/Contents/" "$DEPLOY_PATH/Contents/"
@@ -155,11 +143,19 @@ rsync -a --delete "$STAGED_BUNDLE/Contents/" "$DEPLOY_PATH/Contents/"
 
 Trailing slashes matter: `.../Contents/` → `.../Contents/` copies contents rather than nesting. `--delete` removes files present in the old bundle but not the new one.
 
-If rsync fails (permission denied, disk full, target not found), fail this plugin and continue. Do **not** sudo.
+**File-lock gotcha**: for plugins with bundled native extensions (observed with `Packages/pyarrow` in the MCP Server plugin), the running plugin process holds file handles under `Packages/` that block `rsync --delete` with `unlinkat: Directory not empty`. The current MCP toolset has **no clean way** to stop a plugin without also starting it — there's no `stop_plugin` tool, and calling `restart_plugin` as a "stop" is a false friend because Indigo starts the new process immediately and the new process re-acquires the same locks before our rsync finishes.
 
-**If `--delete` still fails** with "Directory not empty" despite the pre-stop in step 6 (very bundled native extensions may re-grab locks mid-rsync), retry once without `--delete` as a soft fallback — the new files land on top, leftovers from the old version linger in unused directories, log a warning.
+Three pragmatic mitigations, in order:
 
-### 8. Restart the plugin
+1. **Retry without `--delete`** as a soft fallback. The new files land on top of the old ones, leftovers from removed-upstream files linger in unused directories. Log a warning. This is what actually works today.
+2. **Accept the partial state** for plugins where the soft fallback also fails. Report per-plugin failure and continue with the batch.
+3. **File upstream**: open an issue against [`mlamoure/indigo-mcp-server`](https://github.com/mlamoure/indigo-mcp-server) requesting a `stop_plugin` MCP tool (or a `disable_plugin` → rsync → `enable_plugin` flow). When that lands, this step gets a proper pre-stop and the `--delete` pass works reliably.
+
+Do not sleep-loop or `lsof`-poll as a "fake stop" — those are flaky because Indigo may respawn the process between the stop signal and the rsync, and lsof on an NFS/SMB-mounted Plugins dir (cross-mount setups) is unreliable.
+
+If rsync fails for non-lock reasons (permission denied, disk full, target not found), fail this plugin and continue. Do **not** sudo.
+
+### 7. Restart the plugin
 
 ```text
 mcp__indigo__restart_plugin(plugin_id=$BUNDLE_ID)
@@ -167,7 +163,7 @@ mcp__indigo__restart_plugin(plugin_id=$BUNDLE_ID)
 
 **Except** when `$BUNDLE_ID == com.vtmikel.mcp_server` — see the hard limitation section above. Defer this call and tell the user to run it from a fresh session.
 
-### 9. Verify startup
+### 8. Verify startup
 
 Two checks. The **version check is the primary success signal**; the log check is a secondary sanity pass because the exact `TypeVal` severity mapping isn't well-documented and shouldn't be the sole oracle.
 
@@ -196,7 +192,7 @@ Treat missing success marker as inconclusive, not failed, if the version check a
 
 **No rollback.** If the upgrade rsync'd cleanly but the new code throws errors after restart, report the failure and let the user decide whether to revert manually.
 
-### 10. Cleanup
+### 9. Cleanup
 
 ```bash
 rm -rf "$TMPDIR"
@@ -211,9 +207,9 @@ Always run this, even on failure.
 | 404 downloading asset | Step 2 | Try zipball fallback, then store_download fallback, then fail |
 | Zipball has no `.indigoPlugin` at any depth | Step 3 | Corrupted or source-only repo; fail this plugin |
 | Bundle identifier mismatch | Step 4 | Cached metadata wrong; don't rsync, fail |
-| `rsync --delete` "Directory not empty" | Step 7 | Stop was ineffective for this plugin — retry without `--delete` as a soft fallback, leave cleanup to the user |
-| rsync permission denied | Step 7 | Indigo filesystem perms — user resolves manually; continue with other plugins |
-| Plugin restart hangs | Step 8 | MCP `restart_plugin` has its own timeout; if it never returns, report "restart uncertain" |
-| Bundle ID is `com.vtmikel.mcp_server` | Step 8 | Do not call restart; tell user to restart from a fresh session |
-| Log shows errors after restart | Step 9 | Upgrade applied but new code misbehaves; mark failed, suggest release notes |
+| `rsync --delete` "Directory not empty" | Step 6 | Running plugin holds file locks; retry without `--delete` as a soft fallback, leaving stale files from removed-upstream in place. Log a warning. |
+| rsync permission denied | Step 6 | Indigo filesystem perms — user resolves manually; continue with other plugins |
+| Plugin restart hangs | Step 7 | MCP `restart_plugin` has its own timeout; if it never returns, report "restart uncertain" |
+| Bundle ID is `com.vtmikel.mcp_server` | Step 7 | Do not call restart; tell user to restart from a fresh session |
+| Log shows errors after restart | Step 8 | Upgrade applied but new code misbehaves; mark failed, suggest release notes |
 | Deploy path not accessible | Prereq | Cross-mount detection failed; ask user for the mount prefix |


### PR DESCRIPTION
## Summary

All findings from the 2026-04-15 live test run of `/indigo:update-plugins` v1.6.0 against a 56-plugin Indigo install, landed as one v1.7 update. The test run successfully upgraded 5 plugins but surfaced several edge cases the skill wasn't handling:

- **HomeKitLink Siri** couldn't be deployed — its GitHub release ships a source zipball, not a `.indigoPlugin.zip` asset. The registry had a `github` slug but had thrown away the working store download URL during seeding.
- **MCP Server** partial rsync — the skill tried to upgrade the very MCP server it uses to talk to Indigo, hit `rsync --delete` file-lock errors on `Packages/pyarrow`, and would have killed its own connection if the restart had run.
- **Local `GithubInfo` staleness** — 4 plugins had `gh api` 404s because their embedded repo slugs were wrong (`simons-plugins/UKTrains` vs `simons-plugins/indigo-UKTrains`). The registry had working slugs but the resolver didn't fall through.
- **Registry updates too slow** — contributors would need a marketplace release cycle to ship a single-entry PR. That's too much friction for routine registry maintenance.

## Changes

### Registry schema v2
Entries now carry `github` + `store_url` + `store_download` where available, instead of "one OR the other". All 187 GitHub-backed entries now ship with their store download URL as a fallback. Regenerated `data/plugin-source-registry.json` from the original scrape results.

### Live overlay
The skill now looks for `$HOME/.claude/indigo-plugin-source-registry-live.json`, fetched from `raw.githubusercontent.com/simons-plugins/indigo-claude-plugin/main/data/plugin-source-registry.json` with a 6-hour TTL. Bundled file stays as the offline fallback. Contributors PR → merge → live everywhere within 6h, no marketplace release needed. `/indigo:update-plugins refresh` forces a cache bust.

### Download fallback chain
Phase 2 now tries `.indigoPlugin.zip` release asset → GitHub zipball → `store_download` → fail cleanly. Source-only GitHub releases (like HomeKitLink Siri) now work.

### Nested bundle support
`install-workflow.md` step 3 uses `find -maxdepth 3` instead of `-maxdepth 1` to handle zipball-wrapped bundles (`<user>-<repo>-<sha>/<Name>.indigoPlugin/`).

### Stop-before-rsync
New sequence: `restart_plugin` → `rsync` → `restart_plugin`. The pre-stop frees file locks that break `rsync --delete` for plugins with bundled native extensions. A soft fallback retries without `--delete` if locks are very persistent.

### MCP Server self-upgrade guard
`com.vtmikel.mcp_server` is documented as a hard limitation. The workflow deploys the files but skips the `restart_plugin` call (which would kill the skill's own MCP connection), and tells the user the exact restart command to run from a fresh session.

### Fall-through to registry on gh-api 404
On `gh api` failure (404, auth error, anything), the resolver now falls through to the bundled registry instead of marking the plugin unresolved. Fixes the stale-local-GithubInfo case.

### Mount path portability
When the MCP-reported `path` isn't directly accessible (skill running on a different Mac than the Indigo server), the workflow tries common mount prefixes (`/Volumes/Macintosh HD-1`, etc.) and fails with a clear message if none resolve.

### Installed version from Info.plist
Read `PluginVersion` via `PlistBuddy`, not the MCP `version` field (which returns `CFBundleVersion` and is rarely updated). The old behaviour produced wrong diffs for any plugin whose CFBundleVersion lagged the real plugin version.

## Files

- `data/plugin-source-registry.json` — regenerated with schema v2 (187 entries now carry a store_download fallback)
- `skills/update-plugins/SKILL.md` — Phase 2 resolution model, MCP self-upgrade guard, stop-before-rsync safety rule
- `skills/update-plugins/references/discovery.md` — three-source model, registry schema v2, live overlay, gh-404 fall-through
- `skills/update-plugins/references/install-workflow.md` — nested bundle find, stop-before-rsync ordering, MCP Server guard, zipball/store fallback chain, mount portability
- `commands/update-plugins.md` — summary of the above + hard limitation callout in Phase 5
- `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` — version bump `1.6.0 → 1.7.0`

## Test plan

- [ ] `/plugin marketplace update indigo-claude-plugin` loads 1.7.0 cleanly
- [ ] `/indigo:update-plugins` on the same jarvis install now resolves HomeKitLink Siri (via zipball fallback) and the 4 previously-404 plugins (via gh-404 fall-through)
- [ ] MCP Server upgrade path: deploys files, skips restart, reports the exact manual restart command
- [ ] Live overlay fetches from `raw.githubusercontent.com` on first run, caches to `~/.claude/indigo-plugin-source-registry-live.json`, re-uses within 6h
- [ ] `/indigo:update-plugins refresh` deletes the live overlay and re-fetches
- [ ] A plugin whose GitHub release has neither a `.indigoPlugin.zip` asset NOR a zipball that contains a `.indigoPlugin/` bundle fails cleanly with the "no downloadable plugin asset" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added live caching mechanism for faster plugin registry lookups
  * Implemented fallback sources for plugin downloads when primary sources unavailable
  * Enhanced plugin update discovery with improved version detection

* **Improvements**
  * Refined plugin update workflow with better restart and verification handling
  * Updated plugin registry schema to support multiple download sources per plugin
  * Improved special case handling for certain plugin types

* **Chores**
  * Version bumped to 1.7.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->