### PR TITLE
docs: document two related Indigo exec/open() gotchas

### DIFF
--- a/docs/plugin-dev/troubleshooting/common-issues.md
+++ b/docs/plugin-dev/troubleshooting/common-issues.md
@@ -485,16 +485,37 @@ with open(path, encoding="utf-8") as f:
     contents = f.read()
 ```
 
-For the `exec()` pattern (e.g. when one script reuses functions from another):
-```python
-CONTROLLER_PATH = "/Library/Application Support/Perceptive Automation/Python Scripts/Some_Library.py"
-with open(CONTROLLER_PATH, encoding="utf-8") as _f:
-    exec(_f.read())
-```
+For the `exec()` pattern (e.g. when one script reuses functions from another), pass `globals()` explicitly as well — see the next section.
 
 Indigo's own logs, plugin sources, MQTT payloads, and JSON configs are all UTF-8 in practice. Defaulting to `encoding="utf-8"` everywhere is the safe rule.
 
 **Note:** `Path.read_text()` has the same default-encoding issue — pass `encoding="utf-8"` there too if you're using `pathlib`.
+
+### `NameError: name 'log' is not defined` after `exec()`-ing a shared library
+
+**Symptom:** A trigger or action script `exec()`s another script to reuse its functions (the "core-only" / shared-library pattern), but every call to a function from that library raises:
+```
+NameError: name '<function>' is not defined
+```
+The exec call itself succeeds with no error.
+
+**Cause:** Indigo runs embedded trigger/action scripts **inside a function wrapper**, not at true module level. At the point of your `exec()` call, `globals()` and `locals()` are *different* dicts. Python's `exec()` semantics in that case put any new definitions into `locals()` only — i.e. the wrapper function's local scope. The library's functions are defined, but they never reach the global namespace where the subsequent code looks them up.
+
+**Fix:** pass `globals()` to `exec()` explicitly so definitions land in the module global namespace:
+```python
+LIBRARY_PATH = "/Library/Application Support/Perceptive Automation/Python Scripts/Some_Library.py"
+
+with open(LIBRARY_PATH, encoding="utf-8") as _f:
+    exec(_f.read(), globals())   # ← globals() makes the functions visible below
+
+# Now functions defined in Some_Library.py resolve correctly:
+log("Library loaded")
+do_something()
+```
+
+Without `globals()`, `exec()` runs as if inside a class body (per Python's documented behaviour when globals and locals are different) and `def` statements bind names locally.
+
+**Why this is Indigo-specific:** a normal Python script run from the command line has `globals() is locals()` at module level, so bare `exec(code)` works as expected. Indigo's plugin host wraps embedded scripts, breaking that assumption. The pairing of this with the UTF-8 default (above) means the "exec a shared library" pattern needs *both* `encoding="utf-8"` AND `globals()` to work reliably under Indigo.
 
 ## HTTP Responder Issues
 

--- a/docs/plugin-dev/troubleshooting/common-issues.md
+++ b/docs/plugin-dev/troubleshooting/common-issues.md
@@ -450,7 +450,7 @@ See [Python 3 Migration Guide](../../reference/Python3-Migration-Guide.md) for c
 ### `UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2`
 
 **Symptom:**
-```
+```text
 UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position N: ordinal not in range(128)
 ```
 Triggered by code like:
@@ -494,7 +494,7 @@ Indigo's own logs, plugin sources, MQTT payloads, and JSON configs are all UTF-8
 ### `NameError: name 'log' is not defined` after `exec()`-ing a shared library
 
 **Symptom:** A trigger or action script `exec()`s another script to reuse its functions (the "core-only" / shared-library pattern), but every call to a function from that library raises:
-```
+```text
 NameError: name '<function>' is not defined
 ```
 The exec call itself succeeds with no error.

--- a/docs/plugin-dev/troubleshooting/common-issues.md
+++ b/docs/plugin-dev/troubleshooting/common-issues.md
@@ -447,6 +447,55 @@ See [Python 3 Migration Guide](../../reference/Python3-Migration-Guide.md) for c
    indigo.kStateImageSel.NoImage
    ```
 
+### `UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2`
+
+**Symptom:**
+```
+UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position N: ordinal not in range(128)
+```
+Triggered by code like:
+```python
+exec(open(SOME_PATH).read())
+# or
+text = open(some_path).read()
+```
+
+**Cause:** `IndigoPluginHost3` runs Python with a locale that makes the built-in `open()` default to **ASCII** encoding rather than UTF-8. Any source file or text file containing common non-ASCII characters fails to decode:
+
+| Byte sequence | Character | Where it appears |
+|---------------|-----------|------------------|
+| `0xe2 0x80 0x94` | `—` (em-dash) | comments, docstrings, log messages |
+| `0xe2 0x86 0x92` | `→` (arrow) | log messages (`Hall Lamp → blue`) |
+| `0xc2 0xb0` | `°` | temperature strings |
+| `0xc2 0xa3` | `£` | currency in error messages |
+
+This bites:
+- Scripts that `exec()` another script to reuse its functions (the "core-only" / shared-module pattern used by many automation setups)
+- Plugins reading bundled `.json`, `.txt`, or `.py` resource files with bare `open()`
+- Any code that loads UTF-8 user content (MQTT payloads written to disk, scraped web data, etc.)
+
+**Fix:** always pass `encoding="utf-8"` explicitly to `open()` when reading text:
+```python
+# WRONG — relies on Indigo's locale default (ASCII)
+with open(path) as f:
+    contents = f.read()
+
+# RIGHT — explicit UTF-8
+with open(path, encoding="utf-8") as f:
+    contents = f.read()
+```
+
+For the `exec()` pattern (e.g. when one script reuses functions from another):
+```python
+CONTROLLER_PATH = "/Library/Application Support/Perceptive Automation/Python Scripts/Some_Library.py"
+with open(CONTROLLER_PATH, encoding="utf-8") as _f:
+    exec(_f.read())
+```
+
+Indigo's own logs, plugin sources, MQTT payloads, and JSON configs are all UTF-8 in practice. Defaulting to `encoding="utf-8"` everywhere is the safe rule.
+
+**Note:** `Path.read_text()` has the same default-encoding issue — pass `encoding="utf-8"` there too if you're using `pathlib`.
+
 ## HTTP Responder Issues
 
 ### 404 Errors


### PR DESCRIPTION
## Summary

Adds two related, undocumented gotchas to `docs/plugin-dev/troubleshooting/common-issues.md` (under "Python 3 Issues"). Both bite the same "exec another script to reuse its functions" pattern that's common in larger Indigo automation setups.

**Gotcha 1 — `UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2`**
`IndigoPluginHost3` runs Python with a locale that defaults `open()` to **ASCII**. Files containing `—`, `→`, `°`, `£`, accented letters etc. crash on read. Fix: pass `encoding=\"utf-8\"` explicitly to every `open()` call (and to `Path.read_text()`).

**Gotcha 2 — `NameError: name '<function>' is not defined` after `exec()`**
Indigo runs embedded trigger/action scripts **inside a function wrapper**, so `globals()` and `locals()` are different dicts at the `exec()` call site. Per Python's documented semantics, `exec()` then binds new definitions to `locals()` only — they never reach the module globals where subsequent code looks for them. Fix: `exec(code, globals())`.

The two are companions: the "exec a shared library" pattern needs **both** `encoding=\"utf-8\"` AND explicit `globals()` to work reliably under Indigo. Anyone hitting one will likely hit the other next, so they're documented together.

## Why this matters

Hit both on 14-May-2026 during a real automation refactor:
1. Four contact-sensor/router scripts using `exec(open(controller_path).read())` all crashed at byte 134 — the em-dash in the controller's `# Description:` header
2. After fixing with `encoding=\"utf-8\"`, every script then failed with `NameError: name 'log' is not defined` on the next line

Both errors mislead developers: the first blames the file being read, the second suggests the library didn't define the function. Neither symptom points at `open()`'s default encoding or `exec()`'s scope handling.

Pure documentation change — no code touched.

## Test plan

- [x] Both subsections render correctly in `common-issues.md` under \"Python 3 Issues\"
- [x] Markdown table for byte sequences formats correctly
- [x] Code blocks use proper fences
- [x] Cross-reference from UTF-8 section forwards readers to the `exec()`/`globals()` section
- [ ] (reviewer) Check tone/structure matches surrounding subsections

🤖 Generated with [Claude Code](https://claude.com/claude-code)