### PR TITLE
docs: add menu ConfigUI callback references

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "indigo",
       "source": "./",
       "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
-      "version": "1.9.5",
+      "version": "1.9.6",
       "repository": "https://github.com/simons-plugins/indigo-claude-plugin",
       "license": "MIT",
       "keywords": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "indigo",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "description": "Indigo home automation development toolkit \u2014 plugin development, API integration, and control page building",
   "repository": "https://github.com/simons-plugins/indigo-claude-plugin"
 }

--- a/docs/plugin-dev/concepts/configui.md
+++ b/docs/plugin-dev/concepts/configui.md
@@ -340,6 +340,7 @@ To seed fields with computed values when a dialog opens (today's date, the lates
 | Device config | `validateDeviceConfigUi(self, values_dict, type_id, dev_id)` |
 | Action config | `validateActionConfigUi(self, values_dict, type_id, device_id)` |
 | Event config | `validateEventConfigUi(self, values_dict, type_id, event_id)` |
+| Menu item | `validateMenuActionConfigUi(self, values_dict, menu_id)` |
 | Device factory | `validateDeviceFactoryUi(self, values_dict, dev_id_list)` |
 
 ### Return Values
@@ -373,6 +374,7 @@ Called after validation succeeds or user cancels:
 | Device config | `closedDeviceConfigUi(self, values_dict, user_cancelled, type_id, dev_id)` |
 | Action config | `closedActionConfigUi(self, values_dict, user_cancelled, type_id, action_id)` |
 | Event config | `closedEventConfigUi(self, values_dict, user_cancelled, type_id, event_id)` |
+| Menu item | `closedMenuActionConfigUi(self, values_dict, user_cancelled, menu_id)` |
 | Device factory | `closedDeviceFactoryUi(self, values_dict, user_cancelled, dev_id_list)` |
 
 ## SupportURL


### PR DESCRIPTION
Closes #36

Summary:
- add the menu-item validation callback to the ConfigUI callback table
- add the menu-item dialog close callback to the ConfigUI callback table
- bump plugin metadata from 1.9.5 to 1.9.6 for the repository version check

Tests:
- Not run locally
- git diff --check