### PR TITLE
docs: correct the create_clipping.py usage in the control-pages SKILL.md

### DIFF
--- a/skills/control-pages/SKILL.md
+++ b/skills/control-pages/SKILL.md
@@ -46,7 +46,10 @@ Control pages are XML-defined touch interfaces for Indigo, displayed on iOS/macO
 
 ## Essential Rules
 
-- Use 2x (retina) images for all new pages
+- Use 2x (retina) images for all new pages, but check the file exists first —
+  older images such as `lightbulb_large` have no 2x variant, and a missing
+  image renders as a bare caption. Pick from `docs/control-pages/images/`, or
+  confirm against `Web Assets/images/controls/devices/`
 - `ClientActionType` 1014 for dimmers/thermostats (popup control)
 - Empty `ActionGroup` element for display-only sensors
 - Dark theme background: `19 19 19`
@@ -63,8 +66,12 @@ Read `${CLAUDE_PLUGIN_ROOT}/control-pages.local.md` for user-configured defaults
 ## Export Tool
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/tools/create_clipping.py" input.xml output.textClipping
+cat input.xml | python3 "${CLAUDE_PLUGIN_ROOT}/tools/create_clipping.py" output.textClipping
 ```
+
+The script takes the output path as its only positional argument and reads the
+XML from stdin, or from `--xml` as a string. See
+`docs/control-pages/export/clipping-export.md` for the full argument list.
 
 ## Reference Documentation
 


### PR DESCRIPTION
Two small documentation fixes to `skills/control-pages/SKILL.md`, both found while giving the control-pages skill its first proper run — it built me a working page, so thank you for it.

**The export command does not work as written.** SKILL.md has:

```bash
python3 "${CLAUDE_PLUGIN_ROOT}/tools/create_clipping.py" input.xml output.textClipping
```

but the script takes the output path as its only positional argument and reads the XML from stdin or from `--xml`, so that fails with `unrecognized arguments`. `docs/control-pages/export/clipping-export.md` documents it correctly already, so it is only the summary that has drifted from the detail. Since SKILL.md is what gets read first, it is the one that bites. Changed to the stdin form and added a pointer to the fuller doc. I ran the corrected command exactly as written and it produced a valid clipping.

**"Use 2x images for all new pages" needs a small caveat.** It is the right default, but some of the older device images have no 2x variant. I hit it with `lightbulb_large`, which exists as `lightbulb_large.png` and `lightbulb_large+on.png` and nothing else, so taking that name off an existing page and appending " 2x" gives a page element with a caption and no icon. Nothing errors, which is what makes it slow to spot. The note now suggests checking the catalogue under `docs/control-pages/images/` or the images folder itself.

One file, nine lines added, two changed. Happy to adjust the wording if you would rather it read differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated image guidance to require verification of available 2x assets.
  * Added approved image location guidance.
  * Clarified clipping export usage, including XML input from standard input or via an option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->